### PR TITLE
Fix Bayesian Meta-Analysis 2

### DIFF
--- a/R/bayesianmetaanalysiscommon.R
+++ b/R/bayesianmetaanalysiscommon.R
@@ -1236,25 +1236,26 @@
   } 
   
   # Scale the height and width of the plot
-  height <- heightCum <- 100 + nrow(dataset) * 30 
-  if(options$forestPlot == "plotForestBoth") {
-    height <- 100 + nrow(dataset) * 30 + 50 + nrow(dataset) * 30
-  } 
+  heightCum <- 100 + nrow(dataset) * 30 
   width  <- 500 + (nchar(max(studyLabels)) * 5)
   
   # Create empty plot
   if(is.null(forestContainer[["forestPlot"]]) && options$checkForestPlot) {
     
-    # title of plot based on observed/estimated 
-    if(options$forestPlot == "plotForestObserved" || options$modelSpecification == "FE"){
-      title <- gettext("Observed study effects")
+    # title and height of plot based on observed/estimated 
+    if(options$forestPlot == "plotForestObserved"){
+      title  <- gettext("Observed study effects")
+      height <- 100 + nrow(dataset) * 30
     } else if(options$forestPlot == "plotForestEstimated"){
-      title <- gettext("Estimated study effects")
+      title  <- gettext("Estimated study effects")
+      height <- 100 + nrow(dataset) * 30
     } else if(options$forestPlot == "plotForestBoth"){
       title  <- gettext("Observed and estimated study effects")
+      height <- 150 + 2 * (nrow(dataset) * 30)
     }
     
     forestPlot <- createJaspPlot(plot = NULL, title = title, height = height, width = width)
+    
     # Fill plot
     forestPlot$dependOn(c("forestPlot", "checkForestPlot", 
                           "orderForest", "forestPlotOrder", "showLabels"))

--- a/R/bayesianmetaanalysiscommon.R
+++ b/R/bayesianmetaanalysiscommon.R
@@ -663,10 +663,10 @@
   }
   
   if(options$modelSpecification == "CRE"){
-    if(options[["bayesFactorType"]] == "BF01" || options[["bayesFactorType"]] == "LogBF10"){
-      footnoteCREbf <- gettextf("Bayes factor of the ordered effects H%1$s over the fixed effects H%0$s. The Bayes factor for the ordered effects H%1$s versus the unconstrained (random) effects H%1$s model is %2$.3f.", "\u2081", creBF)
-    } else if(options[["bayesFactorType"]] == "BF10"){
-      footnoteCREbf <-gettextf("Bayes factor of the fixed effects H%0$s over the ordered effects H%1$s. The Bayes factor for the unconstrained (random) effects H%1$s versus the ordered effects H%1$s model is %2$.3f.", "\u2081", creBF)
+    if(options[["bayesFactorType"]] == "BF10" || options[["bayesFactorType"]] == "LogBF10"){
+      footnoteCREbf <- gettextf("Bayes factor of the ordered effects H%1$s over the fixed effects H%2$s. The Bayes factor for the ordered effects H%1$s versus the unconstrained (random) effects H%1$s model is %3$.3f.", "\u2081", "\u2080", creBF)
+    } else if(options[["bayesFactorType"]] == "BF01"){
+      footnoteCREbf <-gettextf("Bayes factor of the fixed effects H%2$s over the ordered effects H%1$s. The Bayes factor for the unconstrained (random) effects H%1$s versus the ordered effects H%1$s model is %3$.3f.", "\u2081", "\u2080", creBF)
     }
     
     
@@ -1142,13 +1142,13 @@
     med <- round(med, 3)    
   }
   
-  
-  pizzaTxt <- c("data | f H1", "data | r H1")
-  bfSubscripts <-  c("BF[italic(rf)]", "BF[italic(fr)]")
+  pizzaTxt <- c("data | Hf1",
+                "data | Hr1")
+  bfSubscripts <-  c("BF[italic(r1f1)]", "BF[italic(f1r1)]")
   
   if(options$modelSpecification == "CRE"){
-    pizzaTxt <- c("data | f H1", "data | o H1")
-    bfSubscripts <-  c("BF[italic(of)]", "BF[italic(fo)]")
+    pizzaTxt <- c("data | Hf1", "data | Ho1")
+    bfSubscripts <-  c("BF[italic(o1f1)]", "BF[italic(f1o1)]")
   }
   
   xr   <- range(df$x)
@@ -1236,7 +1236,7 @@
   } 
   
   # Scale the height and width of the plot
-  heightCum <- 100 + nrow(dataset) * 30 
+  heightCumulative <- 100 + nrow(dataset) * 30 
   width  <- 500 + (nchar(max(studyLabels)) * 5)
   
   # Create empty plot
@@ -1266,7 +1266,7 @@
   }
   
   if(is.null(forestContainer[["cumForestPlot"]]) && options$plotCumForest){
-    cumForestPlot <- createJaspPlot(plot = NULL, title = gettext("Cumulative forest plot"), height = heightCum, width = width)
+    cumForestPlot <- createJaspPlot(plot = NULL, title = gettext("Cumulative forest plot"), height = heightCumulative, width = width)
     cumForestPlot$dependOn(c("plotCumForest", "addPrior"))
     cumForestPlot$position <- 2
     .bmaFillCumForest(cumForestPlot, jaspResults, dataset, options, studyLabels, .bmaDependencies)
@@ -1663,9 +1663,15 @@
   } else if(type == "SE"){
     # The BFs for heterogeneity have different labels
     BFs <- rowResults$BFsHeterogeneity
-    yName <- "BF[italic(rf)]"
-    pizzaTxt <- c("data | f", "data | r")
-    bfSubscripts <-  c("BF[italic(rf)]", "BF[italic(fr)]")  
+    if(options$modelSpecification == "BMA"){
+      yName         <- "BF[italic(rf)]"
+      pizzaTxt      <- c("data | Hf", "data | Hr")
+      bfSubscripts  <-  c("BF[italic(rf)]", "BF[italic(fr)]")  
+    } else if(options$modelSpecification == "RE"){
+      yName         <- "BF[italic(r1f1)]"
+      pizzaTxt      <- c("data | Hf1", "data | Hr1")
+      bfSubscripts  <-  c("BF[italic(r1f1)]", "BF[italic(f1r1)]")  
+    }
     arrowLabel <- c(evidenceF, evidenceR)
     BF <- BFs[length(BFs)]
     if(BF >= 1){
@@ -1693,15 +1699,16 @@
   if(options$bayesFactorType == "BF01") {
     BFs    <- 1/BFs
     bfType <- "BF01"
-    yName <- "BF[italic(fr)]" 
+    if(options$modelSpecification == "BMA") yName <- "BF[italic(fr)]" 
+    if(options$modelSpecification == "RE")  yName <- "BF[italic(f1r1)]" 
   } 
   
   # The BFs for constrained random effects also have different labels
   if(options$modelSpecification == "CRE"){
-    pizzaTxt <- c("data | f", "data | o")
-    bfSubscripts <-  c("BF[italic(of)]", "BF[italic(fo)]")
-    if(type == "SE") yName <- "BF[italic(of)]"
-    if(type == "SE" && options$bayesFactorType == "BF01") yName <- "BF[italic(fo)]"
+    pizzaTxt <- c("data | Hf1", "data | Ho1")
+    bfSubscripts <-  c("BF[italic(o1f1)]", "BF[italic(f1o1)]")
+    if(type == "SE") yName <- "BF[italic(o1f1)]"
+    if(type == "SE" && options$bayesFactorType == "BF01") yName <- "BF[italic(f1o1)]"
   }
   
   if(any(is.infinite(BFs))){

--- a/inst/qml/BayesianMetaAnalysis.qml
+++ b/inst/qml/BayesianMetaAnalysis.qml
@@ -87,6 +87,7 @@ Form
 	}
 
 	MA.BayesianMetaAnalysisAdvanced{
+		id:						bayesianMetaAnalysisAdvanced
 		modelTypeValue:			bayesianMetaAnalysisInference.modelTypeValue
 		modelDirectionValue:	bayesianMetaAnalysisInference.modelDirectionValue
 	}

--- a/inst/qml/BayesianMetaAnalysis.qml
+++ b/inst/qml/BayesianMetaAnalysis.qml
@@ -77,6 +77,7 @@ Form
 	}
 
 	MA.BayesianMetaAnalysisPlots{
+		id:						bayesianMetaAnalysisPlots
 		modelTypeValue:			bayesianMetaAnalysisInference.modelTypeValue
 		modelDirectionValue:	bayesianMetaAnalysisInference.modelDirectionValue
 	}

--- a/inst/qml/qml_components/BayesianMetaAnalysisAdvanced.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisAdvanced.qml
@@ -25,6 +25,11 @@ Section
 	columns: 	2
 	title: 		qsTr("Advanced")
 
+	property alias priorH0FEValue:		priorH0FE.value
+	property alias priorH1FEValue:		priorH1FE.value
+	property alias priorH0REValue:		priorH0RE.value
+	property alias priorH1REValue:		priorH1RE.value
+	
 	property string modelTypeValue:			"BMA"
 	property string modelDirectionValue:	"allPos"
 
@@ -34,39 +39,17 @@ Section
 		enabled: 	modelTypeValue == "FE" || modelTypeValue == "RE" || modelTypeValue == "BMA"
 		title: 		qsTr("Prior model probability")
 
-		property double fixedEffectsHypothesisVal:	modelTypeValue == "FE" ? 0.5 :
-														modelTypeValue == "RE" ? 0 :
-															modelTypeValue == "BMA" ? 0.25 : 0
-
-		property double randomEffectsHypothesisVal:	modelTypeValue == "FE" ? 0 :
-														modelTypeValue == "RE" ? 0.5 :
-															modelTypeValue == "BMA" ? 0.25 : 0
-
-		function resetHypotheses() {
-			priorH0FE.value = fixedEffectsHypothesisVal
-			priorH1FE.value = fixedEffectsHypothesisVal
-			priorH0RE.value = randomEffectsHypothesisVal
-			priorH1RE.value = randomEffectsHypothesisVal
-
-			priorH0FE.editingFinished()
-			priorH1FE.editingFinished()
-			priorH0RE.editingFinished()
-			priorH1RE.editingFinished()
-		}
-
 		Group
 		{
 			enabled: 			modelTypeValue == "FE" || modelTypeValue == "BMA"
 			title: 				qsTr("Fixed effects")
-
-			onEnabledChanged: 	if(enabled) priorModelProbabilityGroup.resetHypotheses()
 
 			DoubleField
 			{
 				id: 			priorH0FE
 				name: 			"priorH0FE"
 				label: 			"H\u2080"
-				defaultValue: 	priorModelProbabilityGroup.fixedEffectsHypothesisVal
+				defaultValue: 	0.25
 			}
 
 			DoubleField
@@ -74,7 +57,7 @@ Section
 				id: 			priorH1FE
 				name: 			"priorH1FE"
 				label: 			"H\u2081"
-				defaultValue: 	priorModelProbabilityGroup.fixedEffectsHypothesisVal
+				defaultValue: 	0.25
 			}
 		}
 
@@ -82,14 +65,13 @@ Section
 		{
 			title: 				qsTr("Random effects")
 			enabled: 			modelTypeValue == "RE" || modelTypeValue == "BMA"
-			onEnabledChanged: 	if(enabled) priorModelProbabilityGroup.resetHypotheses()
 
 			DoubleField
 			{
 				id: 			priorH0RE
 				name: 			"priorH0RE"
 				label: 			"H\u2080"
-				defaultValue: 	priorModelProbabilityGroup.randomEffectsHypothesisVal
+				defaultValue: 	0.25
 			}
 
 			DoubleField
@@ -97,7 +79,7 @@ Section
 				id: 			priorH1RE
 				name: 			"priorH1RE"
 				label: 			"H\u2081"
-				defaultValue: 	priorModelProbabilityGroup.randomEffectsHypothesisVal
+				defaultValue: 	0.25
 			}
 		}
 	}

--- a/inst/qml/qml_components/BayesianMetaAnalysisInference.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisInference.qml
@@ -48,6 +48,7 @@ Section
 					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0.5
 					bayesianMetaAnalysisAdvanced.priorH0REValue = 0
 					bayesianMetaAnalysisAdvanced.priorH1REValue = 0
+					bayesianMetaAnalysisPlots.forestObservedClick = true
 				}
 			}
 

--- a/inst/qml/qml_components/BayesianMetaAnalysisInference.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisInference.qml
@@ -44,11 +44,10 @@ Section
 				value: 				"FE"
 				label: 				qsTr("Fixed effects")
 				onCheckedChanged:	{
-					if (checked)
-					{
-						priorModelProbabilityGroup.resetHypotheses()
-						forestObserved.click()
-					}
+					bayesianMetaAnalysisAdvanced.priorH0FEValue = 0.5
+					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0.5
+					bayesianMetaAnalysisAdvanced.priorH0REValue = 0
+					bayesianMetaAnalysisAdvanced.priorH1REValue = 0
 				}
 			}
 
@@ -56,7 +55,12 @@ Section
 			{
 				value: 				"RE"
 				label: 				qsTr("Random effects")
-				onCheckedChanged:	if(checked) priorModelProbabilityGroup.resetHypotheses()
+				onCheckedChanged:	if(checked) {
+					bayesianMetaAnalysisAdvanced.priorH0FEValue = 0
+					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0
+					bayesianMetaAnalysisAdvanced.priorH0REValue = 0.5
+					bayesianMetaAnalysisAdvanced.priorH1REValue = 0.5
+				}
 			}
 
 			RadioButton
@@ -64,14 +68,24 @@ Section
 				value: 				"BMA"
 				label: 				qsTr("Model averaging")
 				checked: 			true
-				onCheckedChanged:	if(checked) priorModelProbabilityGroup.resetHypotheses()
+				onCheckedChanged:	if(checked) {
+					bayesianMetaAnalysisAdvanced.priorH0FEValue = 0.25
+					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0.25
+					bayesianMetaAnalysisAdvanced.priorH0REValue = 0.25
+					bayesianMetaAnalysisAdvanced.priorH1REValue = 0.25
+				}
 			}
 
 			RadioButton
 			{
 				value: 				"CRE"
 				label: 				qsTr("Constrained random effects")
-				onCheckedChanged:	if(checked) priorModelProbabilityGroup.resetHypotheses()
+				onCheckedChanged:	if(checked) {
+					bayesianMetaAnalysisAdvanced.priorH0FEValue = 0.25
+					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0.25
+					bayesianMetaAnalysisAdvanced.priorH0REValue = 0.25
+					bayesianMetaAnalysisAdvanced.priorH1REValue = 0.25
+				}
 
 				// Constrain effect sizes to be all positive or all negative
 				RadioButtonGroup

--- a/inst/qml/qml_components/BayesianMetaAnalysisInference.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisInference.qml
@@ -48,7 +48,7 @@ Section
 					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0.5
 					bayesianMetaAnalysisAdvanced.priorH0REValue = 0
 					bayesianMetaAnalysisAdvanced.priorH1REValue = 0
-					bayesianMetaAnalysisPlots.forestObservedClick = true
+					bayesianMetaAnalysisPlots.plotForestObservedClick = true
 				}
 			}
 
@@ -82,10 +82,10 @@ Section
 				value: 				"CRE"
 				label: 				qsTr("Constrained random effects")
 				onCheckedChanged:	if(checked) {
-					bayesianMetaAnalysisAdvanced.priorH0FEValue = 0.25
-					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0.25
-					bayesianMetaAnalysisAdvanced.priorH0REValue = 0.25
-					bayesianMetaAnalysisAdvanced.priorH1REValue = 0.25
+					bayesianMetaAnalysisAdvanced.priorH0FEValue = 0
+					bayesianMetaAnalysisAdvanced.priorH1FEValue = 0
+					bayesianMetaAnalysisAdvanced.priorH0REValue = 0
+					bayesianMetaAnalysisAdvanced.priorH1REValue = 0
 				}
 
 				// Constrain effect sizes to be all positive or all negative

--- a/inst/qml/qml_components/BayesianMetaAnalysisPlots.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisPlots.qml
@@ -25,7 +25,7 @@ Section
 	columns: 	1
 	title: 		qsTr("Plots")
 
-	property alias forestObservedClick:		forestObserved.checked
+	property alias plotForestObservedClick:	plotForestObserved.checked
 	property string modelTypeValue:			"BMA"
 	property string modelDirectionValue:	"allPos"
 	property string module:					"metaAnalysis"

--- a/inst/qml/qml_components/BayesianMetaAnalysisPlots.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisPlots.qml
@@ -25,6 +25,7 @@ Section
 	columns: 	1
 	title: 		qsTr("Plots")
 
+	property alias forestObservedClick:		forestObserved.checked
 	property string modelTypeValue:			"BMA"
 	property string modelDirectionValue:	"allPos"
 	property string module:					"metaAnalysis"

--- a/inst/qml/qml_components/BayesianMetaAnalysisPlots.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisPlots.qml
@@ -46,7 +46,7 @@ Section
 
 				RadioButton
 				{
-					id:		forestObserved
+					id:		plotForestObserved
 					name: 		"plotForestObserved"
 					label: 		qsTr("Observed")
 					checked: 	true
@@ -54,6 +54,7 @@ Section
 
 				RadioButton
 				{
+					id:		plotForestEstimated
 					enabled: 	!(modelTypeValue == "FE")
 					name: 		"plotForestEstimated"
 					label: 		qsTr("Estimated")
@@ -61,6 +62,7 @@ Section
 
 				RadioButton
 				{
+					id:		plotForestBoth
 					enabled: 	!(modelTypeValue == "FE")
 					name: 		"plotForestBoth"
 					label: 		qsTr("Both")
@@ -127,6 +129,11 @@ Section
 	{
 		name: 	"plotCumForest"
 		label: 	qsTr("Cumulative forest plot")
+		CheckBox
+		{
+			name: "addPrior"
+			label: qsTr("Add prior")
+		}
 	}
 
 	CheckBox

--- a/inst/qml/qml_components/BayesianMetaAnalysisPriors.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisPriors.qml
@@ -176,7 +176,7 @@ Section
 	RadioButtonGroup
 	{
 		enabled:	modelTypeValue == "RE" || modelTypeValue == "CRE" || modelTypeValue == "BMA"
-		title: 		qsTr("Heterogeneity (Between study SD)")
+		title: 		qsTr("Heterogeneity (between-study SD)")
 		name: 		"priorSE"
 
 		RadioButton


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1236
New pull request (old one: #28) because there were merge conflicts with #22.

Regarding one of the comments in #28 about this plot: 
![image](https://user-images.githubusercontent.com/49243293/120461728-8c3b2b80-c39a-11eb-90f7-a5faaaaafb1b.png)

I kept it like this. It is not possible to show `RE H1` because it is too long and the text will be cut off. I think `r H1` would not be too confusing, since the BF is also labeled with just the `r` and the `f`.
