### PR TITLE
adding WAAP-WLS & PET-PEESE + small improvements to selection models

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,6 @@
 import(jaspBase)
 export(ClassicalMetaAnalysis)
 export(SelectionModels)
+export(WaapWlsPetPeese)
 export(BayesianMetaAnalysis)
 export(RobustBayesianMetaAnalysis)

--- a/R/selectionmodels.R
+++ b/R/selectionmodels.R
@@ -16,24 +16,24 @@
 #
 
 SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
-  
+
   if (.smCheckReady(options)) {
     # get the data
     dataset <- .smGetData(dataset, options)
     dataset <- .smCheckData(jaspResults, dataset, options)
-    
+
     # fit the models
     .smFit(jaspResults, dataset, options)
   }
-  
+
   # main summary tables
   .smMakeTestsTables(jaspResults, dataset, options)
   .smMakeEstimatesTables(jaspResults, dataset, options)
-  
+
   # the p-value frequency tables
   if (options[["tablePVal"]])
     .smPFrequencyTable(jaspResults, dataset, options)
-  
+
   # figures
   if (options[["weightFunctionFE"]])
     .smWeightsPlot(jaspResults, dataset, options, "FE")
@@ -41,7 +41,7 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     .smWeightsPlot(jaspResults, dataset, options, "RE")
   if (options[["plotModels"]])
     .smEstimatesPlot(jaspResults, dataset, options)
-  
+
   return()
 }
 
@@ -49,7 +49,7 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
   "joinPVal", "cutoffsPVal", "selectionTwosided", "effectDirection", "measures", "muTransform",
   "inputES", "inputSE", "inputN", "inputPVal"
 )
-
+# check and load functions
 .smCheckReady              <- function(options) {
   if (options[["measures"]] == "general") {
     return(options[["inputES"]] != "" && options[["inputSE"]] != "")
@@ -57,7 +57,6 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     return(options[["inputES"]] != "" && options[["inputN"]] != "")
   }
 }
-
 .smGetData                 <- function(dataset, options) {
   if (!is.null(dataset)) {
     return(dataset)
@@ -70,12 +69,11 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     )))
   }
 }
-
 .smCheckData               <- function(jaspResults, dataset, options) {
-  
+
   dataset_old <- dataset
   dataset     <- na.omit(dataset)
-  
+
   # store the number of missing values
   if (nrow(dataset_old) > nrow(dataset)) {
     if (!is.null(jaspResults[["nOmitted"]])) {
@@ -87,116 +85,114 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     }
     nOmitted$object <- nrow(dataset_old) - nrow(dataset)
   }
-  
+
   .hasErrors(dataset               = dataset,
              type                  = c("infinity", "observations"),
              observations.amount   = "< 2",
              exitAnalysisIfErrors  = TRUE)
-  
+
   if (options[["inputSE"]] != "")
     .hasErrors(dataset               = dataset,
                type                  = c("negativeValues"),
                negativeValues.target = options[["inputSE"]],
                exitAnalysisIfErrors  = TRUE)
-  
-  
+
+
   if (options[["inputN"]] != "")
     .hasErrors(dataset               = dataset,
                type                  = c("negativeValues"),
                negativeValues.target = options[["inputN"]],
                exitAnalysisIfErrors  = TRUE)
-  
-  
-  if (options[["inputPVal"]] != "") 
-    if (any(dataset[, .v(options[["inputPVal"]])] < 0) || any(dataset[, .v(options[["inputPVal"]])] > 1))
+
+
+  if (options[["inputPVal"]] != "")
+    if (any(dataset[, options[["inputPVal"]]] < 0) || any(dataset[, options[["inputPVal"]]] > 1))
       .quitAnalysis(gettextf("Error in %s: All p-values need to be between 0 and 1.", options[["inputPVal"]]))
-  
-  
-  
+
   if (options[["inputES"]] != "" && options[["measures"]] == "correlation")
-    if (any(dataset[, .v(options[["inputES"]])] <= -1) || any(dataset[, .v(options[["inputES"]])] >= 1))
+    if (any(dataset[, options[["inputES"]]] <= -1) || any(dataset[, options[["inputES"]]] >= 1))
       .quitAnalysis(gettextf("Error in %s: All correlation coefficients need to be between -1 and 1.", options[["inputES"]]))
-  
-  
-  
+
+  if (options[["inputN"]] != "" && any(dataset[, options[["inputN"]]] < 4))
+    .quitAnalysis(gettextf("Error in %s: All sample sizes need to be larger than 4.", options[["inputN"]]))
+
+
   return(dataset)
 }
-
 .smGetCutoffs              <- function(options) {
-  
+
   x <- options[["cutoffsPVal"]]
   x <- trimws(x, which = "both")
   x <- trimws(x, which = "both", whitespace = "c")
   x <- trimws(x, which = "both", whitespace = "\\(")
   x <- trimws(x, which = "both", whitespace = "\\)")
   x <- trimws(x, which = "both", whitespace = ",")
-  
+
   x <- strsplit(x, ",", fixed = TRUE)[[1]]
-  
+
   x <- trimws(x, which = "both")
   x <- x[x != ""]
-  
+
   if (anyNA(as.numeric(x)))
     .quitAnalysis(gettext("The p-value cutoffs were set incorectly."))
-  
+
   if (length(x) == 0)
     .quitAnalysis(gettext("At least one p-value cutoff needs to be set."))
-  
+
   x <- as.numeric(x)
   if (options[["selectionTwosided"]])
     x <- c(x/2, 1-x/2)
-  
-  
+
+
   if (any(x <= 0 | x >= 1))
     .quitAnalysis(gettext("All p-value cutoffs needs to be between 0 and 1."))
-  
-  
+
+
   x <- c(sort(x), 1)
-  
+
   return(x)
 }
-
 .smJoinCutoffs             <- function(steps, pVal) {
-  
+
   ### this is probably the most complex part of the analysis
   # the fit function protests when there is any p-value interval with lower than 4 p-values
   # the autoreduce should combine all p-value intervals that have too few p-values
-  
+
   # create p-value table
   cutoffsTable <- table(cut(pVal, breaks = c(0, steps)))
-  
+
   # start removing from the end, but never 1 at the end
   while (cutoffsTable[length(cutoffsTable)] < 4) {
-    
+
     # remove the one before the last step
     steps <- steps[-(length(steps) - 1)]
-    
+
     # create p-value table
     cutoffsTable <- table(cut(pVal, breaks = c(0, steps)))
   }
-  
+
   # and then go from the start(go one by one - two neiboring intervals with 2 p-values will become one with 4 instead of removing all of them)
   while (any(cutoffsTable < 4)) {
-    
+
     # remove the first step that has less than 4 p-values
     steps <- steps[-which.max(cutoffsTable < 4)]
-    
+
     # create p-value table
     cutoffsTable <- table(cut(pVal, breaks = c(0, steps)))
   }
-  
+
   # do not fit the models if there is only one p-value interval
   if (length(steps) <= 1)
     stop("No steps")
-  
-  
+
+
   return(steps)
 }
-
+# fill tables functions
 .smFillEstimates           <- function(jaspResults, table, fit, options) {
-  
+
   overtitleCI <- gettextf("95%% Confidence Interval")
-  
+
   table$addColumnInfo(name = "type",     title = "",                        type = "string")
   table$addColumnInfo(name = "est",      title = gettext("Estimate"),       type = "number")
   table$addColumnInfo(name = "se",       title = gettext("Standard Error"), type = "number")
@@ -204,19 +200,19 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
   table$addColumnInfo(name = "pVal",     title = gettext("p"),              type = "pvalue")
   table$addColumnInfo(name = "lowerCI",  title = gettext("Lower"),          type = "number", overtitle = overtitleCI)
   table$addColumnInfo(name = "upperCI",  title = gettext("Upper"),          type = "number", overtitle = overtitleCI)
-  
+
   rowUnadjusted <- list(type = "Unadjusted")
   rowAdjusted   <- list(type = "Adjusted")
-  
+
   if (!is.null(fit)) {
     if (!class(fit) %in% c("simpleError","error")) {
-      
+
       if (fit[["fe"]]) {
-        posMean <- 1    
+        posMean <- 1
       } else {
         posMean <- 2
       }
-      
+
       rowUnadjusted    <- c(rowUnadjusted, list(
         est  = fit[["unadj_est"]][posMean, 1],
         se   = fit[["unadj_se"]][posMean, 1],
@@ -233,8 +229,8 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
         lowerCI  = fit[["ci.lb_adj"]][posMean, 1],
         upperCI  = fit[["ci.ub_adj"]][posMean, 1]
       ))
-      
-      noteMessages    <- .smSetNoteMessages(jaspResults, fit, options)      
+
+      noteMessages    <- .smSetNoteMessages(jaspResults, fit, options)
       warningMessages <- .smSetWarningMessages(fit)
       for(i in seq_along(noteMessages)) {
         table$addFootnote(symbol = gettext("Note:"),    noteMessages[i])
@@ -242,34 +238,33 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       for(i in seq_along(warningMessages)) {
         table$addFootnote(symbol = gettext("Warning:"), warningMessages[i])
       }
-      
+
     } else {
       errorMessage <- .smSetErrorMessage(fit)
       if (!is.null(errorMessage))
         table$setError(errorMessage)
-    }    
+    }
   }
-  
+
   table$addRows(rowUnadjusted)
   table$addRows(rowAdjusted)
-  
+
   return(table)
 }
-
 .smFillHeterogeneity       <- function(jaspResults, table, fit, options) {
-  
+
   overtitleCI <- gettextf("95%% Confidence Interval")
-  
+
   table$addColumnInfo(name = "type",     title = "",                    type = "string")
   table$addColumnInfo(name = "est",      title = gettext("Estimate"),   type = "number")
   table$addColumnInfo(name = "stat",     title = gettext("z"),          type = "number")
   table$addColumnInfo(name = "pVal",     title = gettext("p"),          type = "pvalue")
   table$addColumnInfo(name = "lowerCI",  title = gettext("Lower"),      type = "number", overtitle = overtitleCI)
   table$addColumnInfo(name = "upperCI",  title = gettext("Upper"),      type = "number", overtitle = overtitleCI)
-  
+
   rowREUnadjustedTau <- list(type = "Unadjusted")
   rowREAdjustedTau   <- list(type = "Adjusted")
-  
+
   if (!is.null(fit)) {
     if (!class(fit) %in% c("simpleError","error")) {
       rowREUnadjustedTau  <- c(rowREUnadjustedTau, list(
@@ -286,16 +281,16 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
         lowerCI  = sqrt(ifelse(fit[["ci.lb_adj"]][1, 1] < 0, 0, fit[["ci.lb_adj"]][1, 1])),
         upperCI  = sqrt(fit[["ci.ub_adj"]][1, 1])
       ))
-      
+
       # add info that tau is on different scale if correlations were used
       if (options[["measures"]] == "correlation")
         table$addFootnote(symbol = gettext("Note:"), gettextf(
-          "%s is on %s scale.", 
+          "%s is on %s scale.",
           "\u03C4",
           if (options[["muTransform"]] == "cohensD") gettext("Cohen's <em>d</em>") else gettext("Fisher's <em>z</em>")
         ))
-      
-      noteMessages    <- .smSetNoteMessages(jaspResults, fit, options)      
+
+      noteMessages    <- .smSetNoteMessages(jaspResults, fit, options)
       warningMessages <- .smSetWarningMessages(fit)
       for(i in seq_along(noteMessages)) {
         table$addFootnote(symbol = gettext("Note:"),    noteMessages[i])
@@ -303,25 +298,24 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       for(i in seq_along(warningMessages)) {
         table$addFootnote(symbol = gettext("Warning:"), warningMessages[i])
       }
-      
+
     } else {
       errorMessage <- .smSetErrorMessage(fit)
       if (!is.null(errorMessage))
         table$setError(errorMessage)
     }
   }
-  
+
   table$addRows(rowREUnadjustedTau)
   table$addRows(rowREAdjustedTau)
-  
+
   return(table)
 }
-
 .smFillWeights             <- function(jaspResults, table, fit, options) {
-  
+
   overtitleCI <- gettextf("95%% Confidence Interval")
   overtitleP  <- gettext("<em>p</em>-values interval(one-sided)")
-  
+
   table$addColumnInfo(name = "lr",       title = gettext("Lower"),          type = "number", overtitle = overtitleP)
   table$addColumnInfo(name = "ur",       title = gettext("Upper"),          type = "number", overtitle = overtitleP)
   table$addColumnInfo(name = "est",      title = gettext("Estimate"),       type = "number")
@@ -330,16 +324,16 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
   table$addColumnInfo(name = "pVal",     title = gettext("p"),              type = "pvalue")
   table$addColumnInfo(name = "lowerCI",  title = gettext("Lower"),          type = "number", overtitle = overtitleCI)
   table$addColumnInfo(name = "upperCI",  title = gettext("Upper"),          type = "number", overtitle = overtitleCI)
-  
+
   if (!is.null(fit)) {
     if (!class(fit) %in% c("simpleError","error")) {
-      
+
       if (fit[["fe"]]) {
-        weightsAdd <- 0  
+        weightsAdd <- 0
       } else {
         weightsAdd <- 1
       }
-      
+
       for(i in 1:length(fit[["steps"]])) {
         if (i == 1) {
           tempRow <- list(
@@ -349,7 +343,7 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
             se   = 0,
             lowerCI  = 1,
             upperCI  = 1
-          )           
+          )
         } else {
           tempRow <- list(
             lr   = fit[["steps"]][i-1],
@@ -360,11 +354,11 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
             pVal = fit[["p_adj"]][i+weightsAdd, 1],
             lowerCI  = ifelse(fit[["ci.lb_adj"]][i+weightsAdd, 1] < 0, 0, fit[["ci.lb_adj"]][i+weightsAdd, 1]),
             upperCI  = fit[["ci.ub_adj"]][i+weightsAdd, 1]
-          ) 
+          )
         }
         table$addRows(tempRow)
       }
-      
+
       noteMessages    <- .smSetNoteMessages(jaspResults, fit, options)
       warningMessages <- .smSetWarningMessages(fit)
       for(i in seq_along(noteMessages)) {
@@ -373,19 +367,19 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       for(i in seq_along(warningMessages)) {
         table$addFootnote(symbol = gettext("Warning:"), warningMessages[i])
       }
-      
+
     } else {
       errorMessage <- .smSetErrorMessage(fit)
       if (!is.null(errorMessage))
         table$setError(errorMessage)
     }
   }
-  
+
   return(table)
 }
-
+# fit models
 .smFit                     <- function(jaspResults, dataset, options) {
-  
+
   if (!is.null(jaspResults[["models"]])) {
     return()
   } else {
@@ -393,17 +387,17 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     models$dependOn(c(.smDependencies, "tablePVal"))
     jaspResults[["models"]] <- models
   }
-  
+
   # get the p-value steps
   steps <- .smGetCutoffs(options)
-  
+
   # get the p-values
-  pVal  <- .smGetInputPVal(dataset, options)
-  
+  pVal  <- .maGetInputPVal(dataset, options)
+
   # remove intervals that do not contain enought(3) p-values
   if (options[["joinPVal"]]) {
     steps <- tryCatch(.smJoinCutoffs(steps, pVal), error = function(e)e)
-    
+
     if (class(steps) %in% c("simpleError", "error")) {
       models[["object"]] <- list(
         FE = steps,
@@ -412,46 +406,47 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       return()
     }
   }
-  
+
+
   # fit the models
   fitFE <- tryCatch(weightr::weightfunct(
-    effect = .smGetInputES(dataset, options),
-    v      = .smGetInputVar(dataset, options),
+    effect = .maGetInputEs(dataset, options),
+    v      = .maGetInputSe(dataset, options)^2,
     pval   = pVal,
     steps  = steps,
     fe     = TRUE
   ),error = function(e)e)
-  
+
   fitRE <- tryCatch(weightr::weightfunct(
-    effect = .smGetInputES(dataset, options),
-    v      = .smGetInputVar(dataset, options),
+    effect = .maGetInputEs(dataset, options),
+    v      = .maGetInputSe(dataset, options)^2,
     pval   = pVal,
     steps  = steps,
     fe     = FALSE
   ),error = function(e)e)
-  
+
   # take care of the possibly turned estimates
   if (options[["effectDirection"]] == "negative") {
     fitFE <- .smTurnEstimatesDirection(fitFE)
-    fitRE <- .smTurnEstimatesDirection(fitRE)  
+    fitRE <- .smTurnEstimatesDirection(fitRE)
   }
-  
+
   # take care of the transformed estimates
   if (options[["measures"]] == "correlation") {
     fitFE <- .smTransformEstimates(fitFE, options)
     fitRE <- .smTransformEstimates(fitRE, options)
   }
-  
+
   models[["object"]] <- list(
     FE = fitFE,
     RE = fitRE
   )
-  
+
   return()
 }
-
+# create the tables
 .smMakeTestsTables         <- function(jaspResults, dataset, options) {
-  
+
   if (!is.null(jaspResults[["fitTests"]])) {
     return()
   } else {
@@ -461,25 +456,25 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     fitTests$dependOn(.smDependencies)
     jaspResults[["fitTests"]] <- fitTests
   }
-  
+
   models   <- jaspResults[["models"]]$object
   errorFE <- class(models$FE) %in% c("simpleError","error")
   errorRE <- class(models$RE) %in% c("simpleError","error")
-  
-  
+
+
   ### test of heterogeneity
   heterogeneityTest <- createJaspTable(title = gettext("Test of Heterogeneity"))
   heterogeneityTest$position <- 1
   fitTests[["heterogeneityTest"]] <- heterogeneityTest
-  
+
   heterogeneityTest$addColumnInfo(name = "stat",  title = gettext("Q"),  type = "number")
   heterogeneityTest$addColumnInfo(name = "df",    title = gettext("df"), type = "integer")
   heterogeneityTest$addColumnInfo(name = "pVal",  title = gettext("p"),  type = "pvalue")
-  
+
   if (!is.null(models)) {
-    
+
     rowHeterogeneity      <- list()
-    
+
     if (!errorFE) {
       rowHeterogeneity    <- c(rowHeterogeneity, list(
         stat = models[["FE"]][["QE"]],
@@ -493,9 +488,9 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
         pVal = models[["RE"]][["QEp"]]
       ))
     }
-    
+
     heterogeneityTest$addRows(rowHeterogeneity)
-    
+
     noteMessages <- unique(c(
       .smSetNoteMessages(jaspResults, models[["FE"]], options), .smSetNoteMessages(jaspResults, models[["RE"]], options)
     ))
@@ -518,29 +513,29 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     if (!.smCheckReady(options) && options[["inputPVal"]] != "")
       heterogeneityTest$addFootnote(symbol = gettext("Note:"), .smSetNoteMessages(NULL, NULL, options))
   }
-  
-  
+
+
   ### test of bias
   biasTest <- createJaspTable(title = gettext("Test of Publication Bias"))
   biasTest$position <- 2
   fitTests[["biasTest"]] <- biasTest
-  
+
   biasTest$addColumnInfo(name = "type",  title = "",                type = "string")
   biasTest$addColumnInfo(name = "stat",  title = gettext("ChiSq"),  type = "number")
   biasTest$addColumnInfo(name = "df",    title = gettext("df"),     type = "integer")
   biasTest$addColumnInfo(name = "pVal",  title = gettext("p"),      type = "pvalue")
-  
+
   if (!is.null(models)) {
-    
+
     rowBiasHomogeneity   <- list(type = gettext("Assuming homogeneity"))
     rowBiasHeterogeneity <- list(type = gettext("Assuming heterogeneity"))
-    
+
     if (!errorFE) {
       rowBiasHomogeneity <- c(rowBiasHomogeneity, list(
         stat = 2*abs(models[["FE"]][["output_unadj"]][["value"]] - models[["FE"]][["output_adj"]][["value"]]),
         df   = length(models[["FE"]][["output_adj"]][["par"]]) - length(models[["FE"]][["output_unadj"]][["par"]]),
         pVal = pchisq(
-          2*abs(models[["FE"]][["output_unadj"]][["value"]] - models[["FE"]][["output_adj"]][["value"]]), 
+          2*abs(models[["FE"]][["output_unadj"]][["value"]] - models[["FE"]][["output_adj"]][["value"]]),
           length(models[["FE"]][["output_adj"]][["par"]]) - length(models[["FE"]][["output_unadj"]][["par"]]),
           lower.tail = FALSE
         )
@@ -551,16 +546,16 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
         stat = 2*abs(models[["RE"]][["output_unadj"]][["value"]] - models[["RE"]][["output_adj"]][["value"]]),
         df   = length(models[["RE"]][["output_adj"]][["par"]]) - length(models[["RE"]][["output_unadj"]][["par"]]),
         pVal = pchisq(
-          2*abs(models[["RE"]][["output_unadj"]][["value"]] - models[["RE"]][["output_adj"]][["value"]]), 
+          2*abs(models[["RE"]][["output_unadj"]][["value"]] - models[["RE"]][["output_adj"]][["value"]]),
           length(models[["RE"]][["output_adj"]][["par"]]) - length(models[["RE"]][["output_unadj"]][["par"]]),
           lower.tail = FALSE
         )
       ))
     }
-    
+
     biasTest$addRows(rowBiasHomogeneity)
     biasTest$addRows(rowBiasHeterogeneity)
-    
+
     noteMessages <- unique(c(
       .smSetNoteMessages(jaspResults, models[["FE"]], options), .smSetNoteMessages(jaspResults, models[["RE"]], options)
     ))
@@ -579,19 +574,18 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     for(i in seq_along(errorMessages)) {
       biasTest$addFootnote(symbol = gettext("Error:"),   errorMessages[i])
     }
-    
+
   } else {
     if (!.smCheckReady(options) && options[["inputPVal"]] != "")
       biasTest$addFootnote(symbol = gettext("Note:"), .smSetNoteMessages(NULL, NULL, options))
   }
-  
+
   return()
 }
-
 .smMakeEstimatesTables     <- function(jaspResults, dataset, options) {
-  
+
   models   <- jaspResults[["models"]]$object
-  
+
   ### assuming homogeneity
   if (is.null(jaspResults[["estimatesFE"]])) {
     # create container
@@ -600,9 +594,9 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     estimatesFE$dependOn(c(.smDependencies, "estimatesFE"))
     jaspResults[["estimatesFE"]] <- estimatesFE
   } else {
-    estimatesFE <- jaspResults[["estimatesFE"]]    
+    estimatesFE <- jaspResults[["estimatesFE"]]
   }
-  
+
   # mean estimates
   if (is.null(estimatesFE[["estimatesFE"]]) && options[["estimatesFE"]]) {
     estimatesMeanFE <- createJaspTable(title = gettextf(
@@ -611,9 +605,9 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     ))
     estimatesMeanFE$position  <- 1
     estimatesFE[["meanFE"]] <- estimatesMeanFE
-    meanFE <- .smFillEstimates(jaspResults, estimatesMeanFE, models[["FE"]], options)    
+    meanFE <- .smFillEstimates(jaspResults, estimatesMeanFE, models[["FE"]], options)
   }
-  
+
   # weights estimates
   if (is.null(estimatesFE[["weightsFE"]]) && options[["weightsFE"]] && options[["estimatesFE"]]) {
     weightsFE <- createJaspTable(title = gettext("Estimated Weights"))
@@ -622,8 +616,8 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     estimatesFE[["weightsFE"]] <- weightsFE
     weightsFE <- .smFillWeights(jaspResults, weightsFE, models[["FE"]], options)
   }
-  
-  
+
+
   ### assuming heterogeneity
   if (is.null(jaspResults[["estimatesRE"]])) {
     # create container
@@ -632,9 +626,9 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     estimatesRE$dependOn(c(.smDependencies, "estimatesRE"))
     jaspResults[["estimatesRE"]] <- estimatesRE
   } else {
-    estimatesRE <- jaspResults[["estimatesRE"]]    
+    estimatesRE <- jaspResults[["estimatesRE"]]
   }
-  
+
   # mean estimates
   if (is.null(estimatesRE[["meanRE"]]) && options[["estimatesRE"]]) {
     estimatesMeanRE <- createJaspTable(title = gettextf(
@@ -643,18 +637,18 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     ))
     estimatesMeanRE$position <- 1
     estimatesRE[["meanRE"]] <- estimatesMeanRE
-    estimatesMeanRE <- .smFillEstimates(jaspResults, estimatesMeanRE, models[["RE"]], options)    
+    estimatesMeanRE <- .smFillEstimates(jaspResults, estimatesMeanRE, models[["RE"]], options)
   }
-  
+
   # tau estimates
   if (is.null(estimatesRE[["heterogeneityRE"]]) && options[["heterogeneityRE"]] && options[["estimatesRE"]]) {
     heterogeneityRE <- createJaspTable(title = gettextf("Heterogeneity Estimates(%s)", "\u03C4"))
     heterogeneityRE$position <- 2
     heterogeneityRE$dependOn(c("heterogeneityRE"))
     estimatesRE[["heterogeneityRE"]] <- heterogeneityRE
-    heterogeneityRE <- .smFillHeterogeneity(jaspResults, heterogeneityRE, models[["RE"]], options)    
+    heterogeneityRE <- .smFillHeterogeneity(jaspResults, heterogeneityRE, models[["RE"]], options)
   }
-  
+
   # weights estimates
   if (is.null(estimatesRE[["weightsRE"]]) && options[["weightsRE"]] && options[["estimatesRE"]]) {
     weightsRE <- createJaspTable(title = gettext("Estimated Weights"))
@@ -662,13 +656,12 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     weightsRE$dependOn(c("weightsRE"))
     estimatesRE[["weightsRE"]] <- weightsRE
     weightsRE <- .smFillWeights(jaspResults, weightsRE, models[["RE"]], options)
-  }  
-  
+  }
+
   return()
 }
-
 .smPFrequencyTable         <- function(jaspResults, dataset, options) {
-  
+
   if (!is.null(jaspResults[["pFrequency"]])) {
     return()
   } else {
@@ -678,25 +671,25 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     pFrequency$dependOn(c(.smDependencies, "tablePVal"))
     jaspResults[["pFrequency"]] <- pFrequency
   }
-  
+
   overtitle <- gettext("<em>p</em>-values interval(one-sided)")
   pFrequency$addColumnInfo(name = "lowerPRange", title = gettext("Lower"),     type = "number", overtitle = overtitle)
   pFrequency$addColumnInfo(name = "upperPRange", title = gettext("Upper"),     type = "number", overtitle = overtitle)
   pFrequency$addColumnInfo(name = "frequency",   title = gettext("Frequency"), type = "integer")
-  
+
   if (!.smCheckReady(options))
     return()
-  
-  
+
+
   models <- jaspResults[["models"]]$object
-  
+
   # get the p-value steps and p-values(so we don't have to search for them in the models)
   steps <- .smGetCutoffs(options)
-  pVal  <- .smGetInputPVal(dataset, options)
-  
+  pVal  <- .maGetInputPVal(dataset, options)
+
   # add a note in case that the models failed to conver due to autoreduce
   if (class(models[["FE"]]) %in% c("simpleError","error") || class(models[["RE"]]) %in% c("simpleError","error")) {
-    
+
     if (options[["joinPVal"]]) {
       if (class(models[["FE"]]) %in% c("simpleError","error") && class(models[["RE"]]) %in% c("simpleError","error")) {
         if (models[["FE"]]$message == "No steps") {
@@ -709,13 +702,13 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     }
   } else {
     if (options[["joinPVal"]]) {
-      steps <- .smJoinCutoffs(steps, pVal)      
+      steps <- .smJoinCutoffs(steps, pVal)
     }
   }
-  
+
   steps <- c(0, steps)
   cutoffsTable <- table(cut(pVal, breaks = steps))
-  
+
   for(i in 1:length(cutoffsTable)) {
     pFrequency$addRows(list(
       lowerPRange = steps[i],
@@ -723,12 +716,12 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       frequency   = cutoffsTable[i]
     ))
   }
-  
+
   return()
 }
-
+# create the plots
 .smWeightsPlot             <- function(jaspResults, dataset, options, type = "FE") {
-  
+
   if (!is.null(jaspResults[[paste0(type, "_weights")]])) {
     return()
   } else {
@@ -743,11 +736,11 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     plotWeights$position <- ifelse(type == "FE", 5, 6)
     jaspResults[[paste0(type, "_weights")]] <- plotWeights
   }
-  
+
   if (!.smCheckReady(options))
     return()
-  
-  
+
+
   # handle errors
   fit <- jaspResults[["models"]]$object[[type]]
   if (class(fit) %in% c("simpleError","error")) {
@@ -756,32 +749,32 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       plotWeights$setError(errorMessage)
     return()
   }
-  
+
   # get the weights and steps
   steps       <- c(0, fit[["steps"]])
   weightsMean <- c(1, fit[["adj_est"]][  ifelse(type == "FE", 2, 3):nrow(fit[["adj_est"]]),  1])
   weightsLowerCI  <- c(1, fit[["ci.lb_adj"]][ifelse(type == "FE", 2, 3):nrow(fit[["ci.lb_adj"]]), 1])
   weightsupperCI  <- c(1, fit[["ci.ub_adj"]][ifelse(type == "FE", 2, 3):nrow(fit[["ci.ub_adj"]]), 1])
-  
+
   # handle NaN in the estimates
   if (any(c(is.nan(weightsMean), is.nan(weightsLowerCI), is.nan(weightsupperCI)))) {
     plotWeights$setError(gettext("The figure could not be created since one of the estimates is not a number."))
     return()
   }
-  
+
   # correct the lower bound
   weightsLowerCI[weightsLowerCI < 0] <- 0
-  
+
   # get the ordering for plotting
   coordOrder <- sort(rep(1:(length(steps)-1),2), decreasing = FALSE)
   stepsOrder <- c(1, sort(rep(2:(length(steps)-1), 2)), length(steps))
-  
+
   # axis ticks
   xTics    <- trimws(steps, which = "both", whitespace = "0")
   xTics[1] <- 0
-  y_tics    <- jaspGraphs::getPrettyAxisBreaks(range(c(weightsMean, weightsLowerCI, weightsupperCI)))
+  yTics    <- jaspGraphs::getPrettyAxisBreaks(range(c(weightsMean, weightsLowerCI, weightsupperCI)))
   xSteps   <- if (options[["weightFunctionRescale"]]) seq(0, 1, length.out = length(steps)) else steps
-  
+
   # make the plot happen
   plot <- ggplot2::ggplot()
   # mean
@@ -798,7 +791,7 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       y = weightsMean[coordOrder]
     ),
     size = 1.25)
-  
+
   plot <- plot + ggplot2::scale_x_continuous(
     gettext("P-value (One-sided)"),
     breaks = xSteps,
@@ -806,17 +799,16 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     limits = c(0, 1))
   plot <- plot + ggplot2::scale_y_continuous(
     gettext("Publication Probability"),
-    breaks = y_tics,
-    limits = range(y_tics))
-  
+    breaks = yTics,
+    limits = range(yTics))
+
   plot <- jaspGraphs::themeJasp(plot)
   plotWeights$plotObject <- plot
-  
+
   return()
 }
-
 .smEstimatesPlot           <- function(jaspResults, dataset, options) {
-  
+
   if (!is.null(jaspResults[["plotEstimates"]])) {
     return()
   } else {
@@ -831,15 +823,15 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     plotEstimates$position <- 7
     jaspResults[["plotEstimates"]] <- plotEstimates
   }
-  
+
   if (!.smCheckReady(options))
     return()
-  
-  
+
+
   # handle errors
   FE <- jaspResults[["models"]]$object[["FE"]]
   RE <- jaspResults[["models"]]$object[["RE"]]
-  
+
   if (class(FE) %in% c("simpleError","error")) {
     errorMessage <- .smSetErrorMessage(FE)
     if (!is.null(errorMessage))
@@ -852,7 +844,7 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
       plotEstimates$setError(errorMessage)
     return()
   }
-  
+
   # get the estimates
   estimates <- data.frame(
     model = c(gettext("Fixed effects"),    gettext("Fixed effects (adjusted)"),    gettext("Random effects"),   gettext("Random effects (adjusted)")),
@@ -861,15 +853,15 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
     upperCI   = c(FE[["ci.ub_unadj"]][1, 1],   FE[["ci.ub_adj"]][1, 1],                RE[["ci.ub_unadj"]][2, 1],   RE[["ci.ub_adj"]][2, 1])
   )
   estimates <- estimates[4:1,]
-  
+
   # handle NaN in the estimates
   if (any(c(is.nan(estimates[,"mean"]), is.nan(estimates[,"lowerCI"]), is.nan(estimates[,"upperCI"]))))
     plotEstimates$setError(gettext("The figure could not be created since one of the estimates is not a number."))
-  
-  
+
+
   # make the plot happen
   plot <- ggplot2::ggplot()
-  
+
   plot <- plot + ggplot2::geom_errorbarh(
     ggplot2::aes(
       xmin = estimates[,"lowerCI"],
@@ -894,32 +886,32 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
   plot <- plot + ggplot2::theme(
     axis.ticks.y = ggplot2::element_blank()
   )
-  
+
   plot <- jaspGraphs::themeJasp(plot, sides = "b")
   plotEstimates$plotObject <- plot
-  
+
   return()
 }
-
+# some additional helpers
 .smSetErrorMessage         <- function(fit, type = NULL) {
-  
+
   if (class(fit) %in% c("simpleError","error")) {
     if (!is.null(type)) {
       model_type <- switch(
         type,
         "FE" = gettext("Fixed effects model: "),
         "RE" = gettext("Random effects model: ")
-      )    
+      )
     } else {
       model_type <- ""
     }
-    
+
     # add more error messages as we find them I guess
     if (fit$message == "non-finite value supplied by optim" || grepl("singular", fit$message)) {
       message <- gettextf("%sThe optimizer failed to find a solution. Consider re-specifying the model or the p-value cutoffs.", model_type)
     } else if (fit$message == "No steps") {
       if (model_type != "")
-        message <- gettextf("%sThe automatic cutoffs selection did not find viable p-value cutoffs. Please, specify them manually.", model_type) 
+        message <- gettextf("%sThe automatic cutoffs selection did not find viable p-value cutoffs. Please, specify them manually.", model_type)
       else
         message <- NULL
     } else {
@@ -928,20 +920,19 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
   } else {
     message <- NULL
   }
-  
+
   return(message)
 }
-
 .smSetWarningMessages      <- function(fit) {
-  
+
   messages   <- NULL
-  
+
   if (!class(fit) %in% c("simpleError","error")) {
-    
+
     ### check for no p-value in cutoffs
     steps <- c(0, fit[["steps"]])
     pVal  <- fit[["p"]]
-    
+
     cutoffsTable <- table(cut(pVal, breaks = steps))
     if (any(cutoffsTable == 0)) {
       messages <- c(messages, gettext(
@@ -952,42 +943,41 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
         "At least one of the p-value intervals contains three or fewer effect sizes, which may lead to estimation problems. Consider re-specifying the cutoffs."
       ))
     }
-    
+
     ### check whether the unadjusted estimates is negative - the weightr assumes that the effect sizes are in expected direction
     if (fit[["unadj_est"]][ifelse(fit[["fe"]], 1, 2), 1] < 0 && is.null(fit[["estimates_turned"]])) {
       messages <- c(messages, gettext(
         "The unadjusted estimate is negative. The selection model default specification expects that the expected direction of the effect size is positive. Please, check that you specified the effect sizes correctly or change the 'Expected effect size direction' option in the 'Model' tab."
       ))
     }
-    
+
   }
-  
+
   return(messages)
 }
-
 .smSetNoteMessages         <- function(jaspResults, fit, options) {
-  
+
   messages <- NULL
-  
+
   if (!.smCheckReady(options) && options[["inputPVal"]] != "") {
-    
+
     messages <- gettext("The analysis requires both 'Effect Size' and 'Effect Size Standard Error' to be specified.")
-    
+
   } else if (!class(fit) %in% c("simpleError","error")) {
-    
+
     # add note about the ommited steps
     steps <- fit[["steps"]]
     steps <- steps
-    
+
     stepsSettings <- .smGetCutoffs(options)
-    
+
     if (!all(stepsSettings %in% steps) && options[["joinPVal"]]) {
       messages      <- c(messages, gettextf(
         "Only the following one-sided p-value cutoffs were used: %s.",
         paste(steps[steps != 1], collapse = ", ")
       ))
     }
-    
+
     if (!is.null(jaspResults[["nOmitted"]])) {
       messages      <- c(messages, sprintf(
         ngettext(
@@ -998,143 +988,76 @@ SelectionModels <- function(jaspResults, dataset, options, state = NULL) {
         jaspResults[["nOmitted"]]$object
       ))
     }
-    
+
   }
-  
-  
+
+
   return(messages)
 }
-
+# effect size transformations
 .smTurnEstimatesDirection  <- function(fit) {
-  
+
   # in the case that the expected direction was negative, the estimated effect sizes will be in the opposite direction
   # this function turns them around
-  
+
   if (!class(fit) %in% c("simpleError","error")) {
-    
+
     if (fit[["fe"]]) {
-      posMean <- 1    
+      posMean <- 1
     } else {
       posMean <- 2
     }
-    
-    fit_old <- fit
-    
-    fit[["unadj_est"]][posMean, 1] <- fit_old[["unadj_est"]][posMean, 1] * -1
-    fit[["z_unadj"]][posMean, 1]   <- fit_old[["z_unadj"]][posMean, 1]   * -1
-    fit[["ci.lb_adj"]][posMean, 1] <- fit_old[["ci.ub_adj"]][posMean, 1] * -1
-    fit[["ci.ub_adj"]][posMean, 1] <- fit_old[["ci.lb_adj"]][posMean, 1] * -1
-    
-    fit[["adj_est"]][posMean, 1]     <- fit_old[["adj_est"]][posMean, 1]     * -1
-    fit[["z_adj"]][posMean, 1]       <- fit_old[["z_adj"]][posMean, 1]       * -1
-    fit[["ci.lb_unadj"]][posMean, 1] <- fit_old[["ci.ub_unadj"]][posMean, 1] * -1
-    fit[["ci.ub_unadj"]][posMean, 1] <- fit_old[["ci.lb_unadj"]][posMean, 1] * -1
-    
-    fit[["output_unadj"]][["par"]][posMean] <- fit_old[["output_unadj"]][["par"]][posMean] * -1    
-    fit[["output_adj"]][["par"]][posMean]   <- fit_old[["output_adj"]][["par"]][posMean]   * -1
-    
+
+    fitOld <- fit
+
+    fit[["unadj_est"]][posMean, 1] <- fitOld[["unadj_est"]][posMean, 1] * -1
+    fit[["z_unadj"]][posMean, 1]   <- fitOld[["z_unadj"]][posMean, 1]   * -1
+    fit[["ci.lb_adj"]][posMean, 1] <- fitOld[["ci.ub_adj"]][posMean, 1] * -1
+    fit[["ci.ub_adj"]][posMean, 1] <- fitOld[["ci.lb_adj"]][posMean, 1] * -1
+
+    fit[["adj_est"]][posMean, 1]     <- fitOld[["adj_est"]][posMean, 1]     * -1
+    fit[["z_adj"]][posMean, 1]       <- fitOld[["z_adj"]][posMean, 1]       * -1
+    fit[["ci.lb_unadj"]][posMean, 1] <- fitOld[["ci.ub_unadj"]][posMean, 1] * -1
+    fit[["ci.ub_unadj"]][posMean, 1] <- fitOld[["ci.lb_unadj"]][posMean, 1] * -1
+
+    fit[["output_unadj"]][["par"]][posMean] <- fitOld[["output_unadj"]][["par"]][posMean] * -1
+    fit[["output_adj"]][["par"]][posMean]   <- fitOld[["output_adj"]][["par"]][posMean]   * -1
+
     fit[["estimates_turned"]] <- TRUE
   }
-  
+
   return(fit)
 }
-
 .smTransformEstimates      <- function(fit, options) {
-  
+
   if (options[["measures"]] == "general")
     return(fit)
-  
+
   # in the case that correlation input was used, this part will transform the results back
   # from the estimation scale to the outcome scale
-  
+
   if (!class(fit) %in% c("simpleError","error")) {
-    
+
     if (fit[["fe"]]) {
-      posMean <- 1    
+      posMean <- 1
     } else {
       posMean <- 2
     }
-    
-    fit_old <- fit
-    
-    
-    fit[["unadj_est"]][posMean, 1] <- .smInvTransform(fit_old[["unadj_est"]][posMean, 1], options[["muTransform"]])
-    fit[["ci.lb_adj"]][posMean, 1] <- .smInvTransform(fit_old[["ci.lb_adj"]][posMean, 1], options[["muTransform"]])
-    fit[["ci.ub_adj"]][posMean, 1] <- .smInvTransform(fit_old[["ci.ub_adj"]][posMean, 1], options[["muTransform"]])
-    
-    fit[["adj_est"]][posMean, 1]     <- .smInvTransform(fit_old[["adj_est"]][posMean, 1],     options[["muTransform"]])
-    fit[["ci.lb_unadj"]][posMean, 1] <- .smInvTransform(fit_old[["ci.lb_unadj"]][posMean, 1], options[["muTransform"]])
-    fit[["ci.ub_unadj"]][posMean, 1] <- .smInvTransform(fit_old[["ci.ub_unadj"]][posMean, 1], options[["muTransform"]])
-    
-    fit[["output_unadj"]][["par"]][posMean] <- .smInvTransform(fit_old[["output_unadj"]][["par"]][posMean], options[["muTransform"]])
-    fit[["output_adj"]][["par"]][posMean]   <- .smInvTransform(fit_old[["output_adj"]][["par"]][posMean],   options[["muTransform"]])
-    
+
+    fitOld <- fit
+
+    fit[["unadj_est"]][posMean, 1]   <- .maInvTransformEs(fitOld[["unadj_est"]][posMean, 1],   options[["muTransform"]])
+    fit[["unadj_se"]][posMean, 1]    <- .maInvTransformSe(fitOld[["unadj_est"]][posMean, 1],   fitOld[["unadj_se"]][posMean, 1], options[["muTransform"]])
+    fit[["ci.lb_unadj"]][posMean, 1] <- .maInvTransformEs(fitOld[["ci.lb_unadj"]][posMean, 1], options[["muTransform"]])
+    fit[["ci.ub_unadj"]][posMean, 1] <- .maInvTransformEs(fitOld[["ci.ub_unadj"]][posMean, 1], options[["muTransform"]])
+
+    fit[["adj_est"]][posMean, 1]     <- .maInvTransformEs(fitOld[["adj_est"]][posMean, 1],   options[["muTransform"]])
+    fit[["adj_se"]][posMean, 1]      <- .maInvTransformSe(fitOld[["adj_est"]][posMean, 1],   fitOld[["adj_se"]][posMean, 1], options[["muTransform"]])
+    fit[["ci.lb_adj"]][posMean, 1]   <- .maInvTransformEs(fitOld[["ci.lb_adj"]][posMean, 1], options[["muTransform"]])
+    fit[["ci.ub_adj"]][posMean, 1]   <- .maInvTransformEs(fitOld[["ci.ub_adj"]][posMean, 1], options[["muTransform"]])
+
     fit[["estimates_transformed"]] <- options[["muTransform"]]
   }
-  
+
   return(fit)
-}
-
-.smGetInputES              <- function(dataset, options) {
-  
-  # change the direction
-  ES <- dataset[, .v(options[["inputES"]])] * ifelse(options[["effectDirection"]] == "negative", -1, 1)
-  
-  # do a scale transform if neccessary
-  if (options[["measures"]] == "general") {
-    return(ES)
-  } else if (options[["measures"]] == "correlation") {
-    return(.smTransform(ES, transformation = options[["muTransform"]], what = "ES"))
-  }
-}
-
-.smGetInputVar             <- function(dataset, options) {
-  
-  # change the direction
-  ES <- .smGetInputES(dataset, options)
-  ES <- ES * ifelse(options[["effectDirection"]] == "negative", -1, 1)
-  
-  # do a scale transform if neccessary
-  if (options[["measures"]] == "general") {
-    return(dataset[, .v(options[["inputSE"]])]^2)
-  } else if (options[["measures"]] == "correlation") {
-    return(.smTransform(ES, dataset[, .v(options[["inputN"]])], transformation = options[["muTransform"]], what = "VAR"))
-  }
-}
-
-.smGetInputPVal            <- function(dataset, options) {
-  # weightfunc uses one-sided p-values as input!
-  if (options[["inputPVal"]] == "") {
-    pVal <- pnorm(
-      .smGetInputES(dataset, options) / sqrt(.smGetInputVar(dataset, options)),
-      lower.tail = FALSE) 
-  } else {
-    pVal <- dataset[, .v(options[["inputPVal"]])]
-  }
-  return(pVal)
-}
-
-.smTransform               <- function(ES, N = NULL, transformation, what) {
-  if (what == "ES") {
-    return(switch(
-      transformation,
-      "cohensD"  = psych::r2d(ES),
-      "fishersZ" = psych::fisherz(ES)
-    ))
-  } else if (what == "VAR") {
-    if (is.null(N))stop("No effect sizes specified to compute the studies' sample variances.")
-    return(switch(
-      transformation,
-      "cohensD"  = N/(N/2)^2 + ES^2/(2*N),
-      "fishersZ" = 1/(N-3)
-    ))
-  }
-}
-
-.smInvTransform            <- function(ES, transformation) {
-  switch(
-    transformation,
-    "cohensD"  = psych::d2r(ES),
-    "fishersZ" = psych::fisherz2r(ES)
-  )
 }

--- a/R/transformations.R
+++ b/R/transformations.R
@@ -1,0 +1,61 @@
+# common effect size transformations for using correlations input in selection models and PET-PEESE
+.maGetInputEs              <- function(dataset, options) {
+
+  if (!is.null(options[["effectDirection"]]) && options[["effectDirection"]] == "negative")
+    dataset[, options[["inputES"]]] <- dataset[, options[["inputES"]]] * - 1
+
+  return(switch(
+    options[["measures"]],
+    "general"     = dataset[, options[["inputES"]]],
+    "correlation" = .maTransformEs(dataset[, options[["inputES"]]], options[["muTransform"]])
+  ))
+}
+.maGetInputSe              <- function(dataset, options) {
+  return(switch(
+    options[["measures"]],
+    "general"     = dataset[, options[["inputSE"]]],
+    "correlation" = .maComputeSe(dataset[, options[["inputES"]]], dataset[, options[["inputN"]]], options[["muTransform"]])
+  ))
+}
+.maGetInputPVal            <- function(dataset, options) {
+  # weightfunc uses one-sided p-values as input!
+  if (options[["inputPVal"]] == "")
+    return(pnorm(.maGetInputEs(dataset, options) /.maGetInputSe(dataset, options), lower.tail = FALSE))
+  else
+    return(dataset[, .v(options[["inputPVal"]])])
+}
+.maTransformEs             <- function(es, transformation) {
+  switch(
+    transformation,
+    "cohensD"  = RoBMA::r2d(r = es),
+    "fishersZ" = RoBMA::r2z(r = es)
+  )
+}
+.maTransformSe             <- function(es, se, transformation) {
+  switch(
+    transformation,
+    "cohensD"  = RoBMA::se_r2se_d(se_r = se, r = es),
+    "fishersZ" = RoBMA::se_r2se_z(se_r = se, r = es)
+  )
+}
+.maComputeSe               <- function(es, n, transformation) {
+  switch(
+    transformation,
+    "cohensD"  = RoBMA::se_d(d = RoBMA::r2d(es), n = n),
+    "fishersZ" = RoBMA::se_z(n = n)
+  )
+}
+.maInvTransformEs          <- function(es, transformation) {
+  switch(
+    transformation,
+    "cohensD"  = RoBMA::d2r(d = es),
+    "fishersZ" = RoBMA::z2r(z = es)
+  )
+}
+.maInvTransformSe          <- function(es, se, transformation) {
+  switch(
+    transformation,
+    "cohensD"  = RoBMA::se_d2se_r(se_d = se, d = es),
+    "fishersZ" = RoBMA::se_z2se_r(se_z = se, z = es)
+  )
+}

--- a/R/waapwlspetpeese.R
+++ b/R/waapwlspetpeese.R
@@ -122,6 +122,10 @@ WaapWlsPetPeese <- function(jaspResults, dataset, options, state = NULL) {
   table$addColumnInfo(name = "upperCI",  title = gettext("Upper"),          type = "number", overtitle = overtitleCI)
 
 
+  if (is.null(models))
+    return(table)
+
+
   for (estimator in c("wls", "waap", "pet", "peese")) {
 
     if (length(models[[estimator]]) == 0)
@@ -160,6 +164,10 @@ WaapWlsPetPeese <- function(jaspResults, dataset, options, state = NULL) {
   table$addColumnInfo(name = "upperCI",  title = gettext("Upper"),          type = "number", overtitle = overtitleCI)
 
 
+  if (is.null(models))
+    return(table)
+
+
   for (estimator in c("pet", "peese")) {
     table$addRows(list(
       type    = toupper(estimator),
@@ -181,6 +189,10 @@ WaapWlsPetPeese <- function(jaspResults, dataset, options, state = NULL) {
 
   table$addColumnInfo(name = "type",     title = "",                        type = "string")
   table$addColumnInfo(name = "est",      title = gettext("Estimate"),       type = "number")
+
+
+  if (is.null(models))
+    return(table)
 
 
   for (estimator in c("wls", "waap", "pet", "peese")) {

--- a/R/waapwlspetpeese.R
+++ b/R/waapwlspetpeese.R
@@ -1,0 +1,603 @@
+#
+# Copyright (C) 2013-2018 University of Amsterdam
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+WaapWlsPetPeese <- function(jaspResults, dataset, options, state = NULL) {
+
+  if (.wwppCheckReady(options)) {
+    # get the data
+    dataset <- .wwppGetData(dataset, options)
+    dataset <- .wwppCheckData(jaspResults, dataset, options)
+
+    # fit the models
+    .wwppFit(jaspResults, dataset, options)
+  }
+
+  # main summary tables
+  .wwppMakeTestsTables(jaspResults, dataset, options)
+  .wwppMakeEstimatesTables(jaspResults, dataset, options)
+
+
+  # figures
+  if (options[["regressionPet"]])
+    .wwppRegressionPlot(jaspResults, dataset, options, "pet")
+  if (options[["regressionPeese"]])
+    .wwppRegressionPlot(jaspResults, dataset, options, "peese")
+  if (options[["plotModels"]])
+    .wwppEstimatesPlot(jaspResults, dataset, options)
+
+  return()
+}
+
+.wwppDependencies <- c("measures", "muTransform", "inputES", "inputSE", "inputN")
+# check and load functions
+.wwppCheckReady              <- function(options) {
+  if (options[["measures"]] == "general") {
+    return(options[["inputES"]] != "" && options[["inputSE"]] != "")
+  } else if (options[["measures"]] == "correlation") {
+    return(options[["inputES"]] != "" && options[["inputN"]] != "")
+  }
+}
+.wwppGetData                 <- function(dataset, options) {
+  if (!is.null(dataset)) {
+    return(dataset)
+  } else {
+    return(.readDataSetToEnd(columns.as.numeric = c(
+      options[["inputES"]],
+      if (options[["inputSE"]] != "") options[["inputSE"]],
+      if (options[["inputN"]]  != "") options[["inputN"]]
+    )))
+  }
+}
+.wwppCheckData               <- function(jaspResults, dataset, options) {
+
+  dataset_old <- dataset
+  dataset     <- na.omit(dataset)
+
+  # store the number of missing values
+  if (nrow(dataset_old) > nrow(dataset)) {
+    if (!is.null(jaspResults[["nOmitted"]])) {
+      nOmitted <- jaspResults[["nOmitted"]]
+    } else {
+      nOmitted <- createJaspState()
+      nOmitted$dependOn(c(.wwppDependencies))
+      jaspResults[["nOmitted"]] <- nOmitted
+    }
+    nOmitted$object <- nrow(dataset_old) - nrow(dataset)
+  }
+
+  .hasErrors(dataset               = dataset,
+             type                  = c("infinity", "observations"),
+             observations.amount   = "< 2",
+             exitAnalysisIfErrors  = TRUE)
+
+  if (options[["inputSE"]] != "")
+    .hasErrors(dataset               = dataset,
+               type                  = c("negativeValues"),
+               negativeValues.target = options[["inputSE"]],
+               exitAnalysisIfErrors  = TRUE)
+
+  if (options[["inputN"]] != "")
+    .hasErrors(dataset               = dataset,
+               type                  = c("negativeValues"),
+               negativeValues.target = options[["inputN"]],
+               exitAnalysisIfErrors  = TRUE)
+
+
+  if (options[["inputES"]] != "" && options[["measures"]] == "correlation")
+    if (any(dataset[, options[["inputES"]]] <= -1) || any(dataset[, options[["inputES"]]] >= 1))
+      .quitAnalysis(gettextf("Error in %s: All correlation coefficients need to be between -1 and 1.", options[["inputES"]]))
+
+  if (options[["inputN"]] != "" && any(dataset[, options[["inputN"]]] < 4))
+    .quitAnalysis(gettextf("Error in %s: All sample sizes need to be larger than 4.", options[["inputN"]]))
+
+
+  return(dataset)
+}
+# fill tables functions
+.wwppFillEstimates           <- function(jaspResults, table, models, options) {
+
+  overtitleCI <- gettextf("95%% Confidence Interval")
+
+  table$addColumnInfo(name = "type",     title = "",                        type = "string")
+  table$addColumnInfo(name = "est",      title = gettext("Estimate"),       type = "number")
+  table$addColumnInfo(name = "se",       title = gettext("Standard Error"), type = "number")
+  table$addColumnInfo(name = "stat",     title = gettext("t"),              type = "number")
+  table$addColumnInfo(name = "df",       title = gettext("df"),             type = "integer")
+  table$addColumnInfo(name = "pVal",     title = gettext("p"),              type = "pvalue")
+  table$addColumnInfo(name = "lowerCI",  title = gettext("Lower"),          type = "number", overtitle = overtitleCI)
+  table$addColumnInfo(name = "upperCI",  title = gettext("Upper"),          type = "number", overtitle = overtitleCI)
+
+
+  for (estimator in c("wls", "waap", "pet", "peese")) {
+
+    if (length(models[[estimator]]) == 0)
+      table$addRows(list(
+        type    = toupper(estimator)
+      ))
+    else
+      table$addRows(list(
+        type    = toupper(estimator),
+        est     = models[[estimator]]["(Intercept)", "Estimate"],
+        se      = models[[estimator]]["(Intercept)", "Std. Error"],
+        stat    = models[[estimator]]["(Intercept)", "t value"],
+        df      = attr(models[[estimator]], "df"),
+        pVal    = models[[estimator]]["(Intercept)", "Pr(>|t|)"],
+        lowerCI = models[[estimator]]["(Intercept)", "lCI"],
+        upperCI = models[[estimator]]["(Intercept)", "uCI"]
+      ))
+
+  }
+
+  .wwppAddWaapFootnote(table, models[["waap"]])
+
+  return(table)
+}
+.wwppFillPetPeese            <- function(jaspResults, table, models, options) {
+
+  overtitleCI <- gettextf("95%% Confidence Interval")
+
+  table$addColumnInfo(name = "type",     title = "",                        type = "string")
+  table$addColumnInfo(name = "est",      title = gettext("Estimate"),       type = "number")
+  table$addColumnInfo(name = "se",       title = gettext("Standard Error"), type = "number")
+  table$addColumnInfo(name = "stat",     title = gettext("t"),              type = "number")
+  table$addColumnInfo(name = "df",       title = gettext("df"),             type = "integer")
+  table$addColumnInfo(name = "pVal",     title = gettext("p"),              type = "pvalue")
+  table$addColumnInfo(name = "lowerCI",  title = gettext("Lower"),          type = "number", overtitle = overtitleCI)
+  table$addColumnInfo(name = "upperCI",  title = gettext("Upper"),          type = "number", overtitle = overtitleCI)
+
+
+  for (estimator in c("pet", "peese")) {
+    table$addRows(list(
+      type    = toupper(estimator),
+      est     = models[[estimator]][toupper(estimator), "Estimate"],
+      se      = models[[estimator]][toupper(estimator), "Std. Error"],
+      stat    = models[[estimator]][toupper(estimator), "t value"],
+      df      = attr(models[[estimator]], "df"),
+      pVal    = models[[estimator]][toupper(estimator), "Pr(>|t|)"],
+      lowerCI = models[[estimator]][toupper(estimator), "lCI"],
+      upperCI = models[[estimator]][toupper(estimator), "uCI"]
+    ))
+  }
+
+  return(table)
+}
+.wwppFillHeterogeneity       <- function(jaspResults, table, models, options) {
+
+  overtitleCI <- gettextf("95%% Confidence Interval")
+
+  table$addColumnInfo(name = "type",     title = "",                        type = "string")
+  table$addColumnInfo(name = "est",      title = gettext("Estimate"),       type = "number")
+
+
+  for (estimator in c("wls", "waap", "pet", "peese")) {
+
+    if (length(models[[estimator]]) == 0 && estimator == "waap") {
+      table$addFootnote(symbol = gettextf("Error: There was not enough adequatelly powered studies (k = %1$i)", attr(models[["waap"]], "nPowered")))
+    } else {
+      table$addRows(list(
+        type    = toupper(estimator),
+        est     = attr(models[[estimator]], "sigma")
+      ))
+      if (estimator == "waap")
+        table$addFootnote(symbol = gettextf("Note: There were %1$i adequatelly powered studies", attr(models[["waap"]], "nPowered")))
+    }
+  }
+
+  return(table)
+}
+# fit models (the fitting functions are adapted from Carter et al., 2019)
+.wwppFit                     <- function(jaspResults, dataset, options) {
+
+  if (!is.null(jaspResults[["models"]])) {
+    return()
+  } else {
+    models <- createJaspState()
+    models$dependOn(c(.wwppDependencies, "tablePVal"))
+    jaspResults[["models"]] <- models
+  }
+
+  summaryWls   <- .wwppWls(  .maGetInputEs(dataset, options), .maGetInputSe(dataset, options))
+  summaryWaap  <- .wwppWaap( .maGetInputEs(dataset, options), .maGetInputSe(dataset, options))
+  summaryPet   <- .wwppPet(  .maGetInputEs(dataset, options), .maGetInputSe(dataset, options))
+  summaryPeese <- .wwppPeese(.maGetInputEs(dataset, options), .maGetInputSe(dataset, options))
+
+
+  # take care of the transformed estimates
+  if (options[["measures"]] == "correlation") {
+    summaryWls   <- .wwppTransformEstimates(summaryWls,   options)
+    summaryWaap  <- .wwppTransformEstimates(summaryWaap,  options)
+    summaryPet   <- .wwppTransformEstimates(summaryPet,   options)
+    summaryPeese <- .wwppTransformEstimates(summaryPeese, options)
+  }
+
+  models[["object"]] <- list(
+    wls   = summaryWls,
+    waap  = summaryWaap,
+    pet   = summaryPet,
+    peese = summaryPeese
+  )
+
+  return()
+}
+.wwppPet                     <- function(y, se) {
+
+  lmPet      <- lm(y ~ se, weights = 1/se^2)
+  summaryPet <- as.data.frame(summary(lmPet)$coefficients)
+  summaryPet <- .wwppAddCi(summaryPet)
+
+  row.names(summaryPet)[2]  <- "PET"
+  attr(summaryPet, "df")    <- length(y) - 2
+  attr(summaryPet, "sigma") <- sigma(lmPet)
+  attr(summaryPet, "fit")   <- lmPet
+  attr(summaryPet, "y")     <- y
+  attr(summaryPet, "se")    <- se
+
+  return(summaryPet)
+}
+.wwppPeese                   <- function(y, se) {
+
+  lmPeese      <- lm(y ~ I(se^2), weights = 1/se^2)
+  summaryPeese <- as.data.frame(summary(lmPeese)$coefficients)
+  summaryPeese <- .wwppAddCi(summaryPeese)
+
+  row.names(summaryPeese)[2]  <- "PEESE"
+  attr(summaryPeese, "df")    <- length(y) - 2
+  attr(summaryPeese, "sigma") <- sigma(lmPeese)
+  attr(summaryPeese, "fit")   <- lmPeese
+  attr(summaryPeese, "y")     <- y
+  attr(summaryPeese, "se")    <- se
+
+  return(summaryPeese)
+}
+.wwppWls                     <- function(y, se) {
+
+  lmWls      <- lm(y ~ 1, weights = 1/se^2)
+  summaryWls <- as.data.frame(summary(lmWls)$coefficients)
+  summaryWls <- .wwppAddCi(summaryWls)
+
+  attr(summaryWls, "df")    <- length(y) - 1
+  attr(summaryWls, "sigma") <- sigma(lmWls)
+  attr(summaryWls, "fit")   <- lmWls
+  attr(summaryWls, "y")     <- y
+  attr(summaryWls, "se")    <- se
+
+  return(summaryWls)
+}
+.wwppWaap                    <- function(y, se) {
+
+  summaryWls <- .wwppWls(y, se)
+  powered    <- abs(summaryWls["(Intercept)", "Estimate"] / 2.8) >= se
+
+  if(sum(powered) >= 2){
+    summaryWaap <- .wwppWls(y[powered], se[powered])
+  }else{
+    summaryWaap <- list()
+  }
+
+  attr(summaryWaap, "nPowered") <- sum(powered)
+
+  return(summaryWaap)
+}
+# create the tables
+.wwppMakeTestsTables         <- function(jaspResults, dataset, options) {
+
+  if (!is.null(jaspResults[["fitTests"]])) {
+    return()
+  } else {
+    # create container
+    fitTests <- createJaspContainer(title = gettext("Model Tests"))
+    fitTests$position <- 1
+    fitTests$dependOn(.wwppDependencies)
+    jaspResults[["fitTests"]] <- fitTests
+  }
+
+  models   <- jaspResults[["models"]]$object
+
+  ### test of effect
+  effectTest <- createJaspTable(title = gettext("Test of Effect"))
+  effectTest$position <- 1
+  fitTests[["effectTest"]] <- effectTest
+
+  effectTest$addColumnInfo(name = "type",  title = "",            type = "string")
+  effectTest$addColumnInfo(name = "stat",  title = gettext("t"),  type = "number")
+  effectTest$addColumnInfo(name = "df",    title = gettext("df"), type = "integer")
+  effectTest$addColumnInfo(name = "pVal",  title = gettext("p"),  type = "pvalue")
+
+  if (!is.null(models)) {
+
+    # WLS
+    effectTest$addRows(list(
+      type = "WLS",
+      stat = models[["wls"]]["(Intercept)", "t value"],
+      df   = attr(models[["wls"]], "df"),
+      pVal = models[["wls"]]["(Intercept)", "Pr(>|t|)"]
+    ))
+
+    # WAAP
+    .wwppAddWaapFootnote(effectTest, models[["waap"]])
+    if (length(models[["waap"]]) == 0)
+      effectTest$addRows(list(type = "WAAP"))
+    else
+      effectTest$addRows(list(
+        type = "WAAP",
+        stat = models[["waap"]]["(Intercept)", "t value"],
+        df   = attr(models[["waap"]], "df"),
+        pVal = models[["waap"]]["(Intercept)", "Pr(>|t|)"]
+      ))
+
+    # PET
+    effectTest$addRows(list(
+      type = "PET",
+      stat = models[["pet"]]["(Intercept)", "t value"],
+      df   = attr(models[["pet"]], "df"),
+      pVal = models[["pet"]]["(Intercept)", "Pr(>|t|)"]
+    ))
+  }
+
+
+  ### test of bias
+  biasTest <- createJaspTable(title = gettext("Test of Publication Bias"))
+  biasTest$position <- 2
+  fitTests[["biasTest"]] <- biasTest
+
+  biasTest$addColumnInfo(name = "type",  title = "",                type = "string")
+  biasTest$addColumnInfo(name = "stat",  title = gettext("t"),      type = "number")
+  biasTest$addColumnInfo(name = "df",    title = gettext("df"),     type = "integer")
+  biasTest$addColumnInfo(name = "pVal",  title = gettext("p"),      type = "pvalue")
+
+  if (!is.null(models)) {
+
+    biasTest$addRows(list(
+      type = "PET",
+      stat = models[["pet"]]["PET", "t value"],
+      df   = attr(models[["pet"]], "df"),
+      pVal = models[["pet"]]["PET", "Pr(>|t|)"]
+    ))
+
+  }
+
+  return()
+}
+.wwppMakeEstimatesTables     <- function(jaspResults, dataset, options) {
+
+  models   <- jaspResults[["models"]]$object
+
+  ### assuming heterogeneity
+  if (is.null(jaspResults[["estimates"]])) {
+    # create container
+    estimates <- createJaspContainer(title = gettext("Estimates"))
+    estimates$position <- 2
+    estimates$dependOn(c(.wwppDependencies, "estimates"))
+    jaspResults[["estimates"]] <- estimates
+  } else {
+    estimates <- jaspResults[["estimates"]]
+  }
+
+  # mean estimates
+  if (is.null(estimates[["mean"]]) && options[["estimatesMean"]]) {
+    estimatesMean <- createJaspTable(title = gettextf(
+      "Mean Estimates(%s)",
+      if (options[["measures"]] == "correlation") "\u03C1" else "\u03BC"
+    ))
+    estimatesMean$position <- 1
+    estimates$dependOn(c("estimatesMean"))
+    estimates[["estimatesMean"]] <- estimatesMean
+    estimatesMean <- .wwppFillEstimates(jaspResults, estimatesMean, models, options)
+  }
+
+  # PET-PEESE estimates
+  if (is.null(estimates[["petPeese"]]) && options[["estimatesPetPeese"]]) {
+    petPeese <- createJaspTable(title = gettext("PET-PEESE Regression Estimates"))
+    petPeese$position  <- 2
+    petPeese$dependOn(c("estimatesPetPeese"))
+    estimates[["petPeese"]] <- petPeese
+    petPeese <- .wwppFillPetPeese(jaspResults, petPeese, models, options)
+  }
+
+  # heterogeneity estimates
+  if (is.null(estimates[["heterogeneity"]]) && options[["estimatesSigma"]]) {
+    heterogeneity <- createJaspTable(title = gettext("Multiplicative Heterogeneity Estimates"))
+    heterogeneity$position <- 3
+    heterogeneity$dependOn(c("estimatesSigma"))
+    estimates[["heterogeneity"]] <- heterogeneity
+    heterogeneity <- .wwppFillHeterogeneity(jaspResults, heterogeneity, models, options)
+  }
+
+  return()
+}
+# create the plots
+.wwppRegressionPlot          <- function(jaspResults, dataset, options, type = "pet") {
+
+  if (!is.null(jaspResults[[paste0(type, "Regression")]])) {
+    return()
+  } else {
+    plotRegression <- createJaspPlot(
+      title  = gettextf("Estimated %1$s Regression", toupper(type)),
+      width  = 500,
+      height = 400)
+    plotRegression$dependOn(c(.wwppDependencies, switch(type, "pet" = "regressionPet", "peese" = "regressionPeese")))
+    plotRegression$position <- switch(type, "pet" = 5, "peese" = 6)
+    jaspResults[[paste0(type, "Regression")]] <- plotRegression
+  }
+
+  if (!.wwppCheckReady(options))
+    return()
+
+
+  # get the fit
+  fit   <- attr(jaspResults[["models"]]$object[[type]], "fit")
+  fitEs <- attr(jaspResults[["models"]]$object[[type]], "y")
+  fitSe <- attr(jaspResults[["models"]]$object[[type]], "se")
+
+  # get the regression line prediction
+  fitSeRange    <- range(jaspGraphs::getPrettyAxisBreaks(c(0, fitSe)))
+  fitSeSequence <- seq(fitSeRange[1], fitSeRange[2], length.out = 101)
+  fitPrediction <- predict(fit, newdata = data.frame(se = fitSeSequence), interval = "confidence")
+
+  if (options[["measures"]] == "correlation")
+    yLabel <- switch(
+      options[["muTransform"]],
+      "cohensD"  = gettext("Cohen's d"),
+      "fishersZ" = gettext("Fisher's z"))
+  else
+    yLabel <- gettext("Effect Size")
+
+  # make the plot happen
+  plot <- ggplot2::ggplot()
+  # mean
+  plot <- plot + ggplot2::geom_polygon(
+    ggplot2::aes(
+      x = c(fitSeSequence, rev(fitSeSequence)),
+      y = c(fitPrediction[,"lwr"], rev(fitPrediction[,"upr"]))
+    ),
+    fill = "grey80")
+  # CI
+  plot <- plot +ggplot2::geom_path(
+    ggplot2::aes(
+      x = fitSeSequence,
+      y = fitPrediction[,"fit"]
+    ),
+    size = 1.25)
+
+  plot <- plot + ggplot2::scale_x_continuous(
+    gettext("Standard Error"),
+    breaks = jaspGraphs::getPrettyAxisBreaks(c(0, fitSe)),
+    limits = range(jaspGraphs::getPrettyAxisBreaks(c(0, fitSe))),
+    oob    = scales::oob_keep)
+  plot <- plot + ggplot2::scale_y_continuous(
+    yLabel,
+    breaks = jaspGraphs::getPrettyAxisBreaks(c(fitPrediction[,"fit"], fitEs)),
+    limits = range(jaspGraphs::getPrettyAxisBreaks(c(fitPrediction[,"fit"], fitEs))),
+    oob    = scales::oob_keep)
+  plot <- plot + ggplot2::geom_point(
+    ggplot2::aes(
+      x  = fitSe,
+      y  = fitEs),
+    size  = 2,
+    shape = 18
+  )
+
+  plot <- jaspGraphs::themeJasp(plot)
+  plotRegression$plotObject <- plot
+
+  return()
+}
+.wwppEstimatesPlot           <- function(jaspResults, dataset, options) {
+
+  if (!is.null(jaspResults[["plotEstimates"]])) {
+    return()
+  } else {
+    plotEstimates <- createJaspPlot(
+      title  = gettextf(
+        "Mean Model Estimates (%s)",
+        if (options[["measures"]] == "correlation") "\u03C1" else "\u03BC"
+      ),
+      width  = 500,
+      height = 200)
+    plotEstimates$dependOn(c(.wwppDependencies, "plotModels"))
+    plotEstimates$position <- 7
+    jaspResults[["plotEstimates"]] <- plotEstimates
+  }
+
+
+  models <- jaspResults[["models"]]$object
+  if (is.null(models))
+    return()
+
+  # get the estimates
+  estimates <- data.frame()
+  for (estimator in c("wls", "waap", "pet", "peese")) {
+    if (length(models[[estimator]]) != 0)
+      estimates <- rbind(estimates, data.frame(
+        model   = toupper(estimator),
+        mean    = models[[estimator]]["(Intercept)", "Estimate"],
+        lowerCI = models[[estimator]]["(Intercept)", "lCI"],
+        upperCI = models[[estimator]]["(Intercept)", "uCI"]
+      ))
+  }
+  estimates <- estimates[nrow(estimates):1, ]
+
+  # handle NaN in the estimates
+  if (any(c(is.nan(estimates[,"mean"]), is.nan(estimates[,"lowerCI"]), is.nan(estimates[,"upperCI"]))))
+    plotEstimates$setError(gettext("The figure could not be created since one of the estimates is not a number."))
+
+
+  # make the plot happen
+  plot <- ggplot2::ggplot()
+
+  plot <- plot + ggplot2::geom_errorbarh(
+    ggplot2::aes(
+      xmin = estimates[,"lowerCI"],
+      xmax = estimates[,"upperCI"],
+      y    = 1:nrow(estimates)
+    ))
+  plot   <- plot + ggplot2::geom_point(
+    ggplot2::aes(
+      x = estimates[,"mean"],
+      y = 1:nrow(estimates)),
+    shape = 15)
+  plot <- plot + ggplot2::geom_line(ggplot2::aes(x = c(0,0), y = c(.5, nrow(estimates) + 0.5)), linetype = "dotted")
+  plot <- plot + ggplot2::scale_x_continuous(
+    gettextf("Mean Estimates (%s)", if (options[["measures"]] == "correlation") "\u03C1" else "\u03BC"),
+    breaks = jaspGraphs::getPrettyAxisBreaks(range(c(0, estimates[,"lowerCI"], estimates[,"upperCI"]))),
+    limits = range(c(0, estimates[,"lowerCI"], estimates[,"upperCI"])))
+  plot <- plot + ggplot2::scale_y_continuous(
+    "",
+    breaks = 1:nrow(estimates),
+    labels = estimates[,"model"],
+    limits = c(0.5, nrow(estimates) + 0.5))
+  plot <- plot + ggplot2::theme(
+    axis.ticks.y = ggplot2::element_blank()
+  )
+
+  plot <- jaspGraphs::themeJasp(plot, sides = "b")
+  plotEstimates$plotObject <- plot
+
+  return()
+}
+# effect size transformations
+.wwppTransformEstimates      <- function(fit, options) {
+
+  if (options[["measures"]] == "general" || length(fit) == 0)
+    return(fit)
+
+  # in the case that correlation input was used, this part will transform the results back
+  # from the estimation scale to the outcome scale
+  for (i in 1:nrow(fit)) {
+    fit["(Intercept)", "Std. Error"]                <- .maInvTransformSe(fit["(Intercept)", "Estimate"], fit["(Intercept)", "Std. Error"], options[["muTransform"]])
+    fit["(Intercept)", c("Estimate", "lCI", "uCI")] <- .maInvTransformEs(fit["(Intercept)", c("Estimate", "lCI", "uCI")],      options[["muTransform"]])
+  }
+
+  return(fit)
+}
+# some additional helpers
+.wwppAddCi                   <- function(summaryFit) {
+
+  summaryFit$lCI <- summaryFit[, "Estimate"] + qnorm(0.025) * summaryFit[, "Std. Error"]
+  summaryFit$uCI <- summaryFit[, "Estimate"] + qnorm(0.975) * summaryFit[, "Std. Error"]
+
+  return(summaryFit)
+}
+.wwppAddWaapFootnote         <- function(table, waap) {
+
+  if (is.null(waap))
+    return()
+  else if (length(waap) == 0)
+    table$addFootnote(symbol = gettext("Warning:") , gettextf("There were only %1$i adequatelly powered studies. WAAP was not estimated.", attr(waap, "nPowered")))
+  else
+    table$addFootnote(gettextf("There were %1$i adequatelly powered studies", attr(waap, "nPowered")))
+}

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -28,6 +28,13 @@ Description
 		requiresData:	true
 	}
 
+	Analysis
+	{
+		title:			qsTr("WAAP-WLS & PET-PEESE")
+		func:			"WaapWlsPetPeese"
+		requiresData:	true
+	}
+
 	Separator{}
 
 	Analysis

--- a/inst/help/selectionmodels.md
+++ b/inst/help/selectionmodels.md
@@ -1,18 +1,18 @@
 Robust Bayesian Meta-Analysis
 ===
 
-The selection models allow the user to specify a publication bias adjusted random and fixed effects meta-analytic models. The options allow the user to specify the selection process using either one or two-sided p-value cutoffs, which are internally transformed to one-sided p-value cutoffs prior to the fitting process.
+The selection models are meta-analytic methods on the fixed and random effects meta-analytic models that adjust for publication bias operating on p-values (Iyengar & Greenhouse, 1988; Vevea & Hedges, 1995). The analysis allow users to specify the selection process using either one or two-sided p-value cutoffs, which are internally transformed to one-sided p-value cutoffs prior to the fitting process.
 
 ### Input
 ---
 #### Input type
 - Effect sizes & SE: Specifying input using any other types of effect sizes and standard errors. One-sided p-values can be supplied as an optional input, if not provided, the p-values are computed using z-aproximation.
-- Correlations & N: Specifying input using correlations and the sample size. Note that the effect size is internally transformed to Cohen's d scale for model estimation (see Model tab for additional options). The output for the mean parameter is transformed back for easier interpretability, however, the heterogeneity parameter is always summarized on the transformed scale. One-sided p-values can be supplied as an optional input, if not provided, the p-values are computed using from the given correlation coefficients and sample sizes.
+- Correlations & N: Specifying input using correlations and the sample size. Note that the effect size is internally transformed to Cohen's d scale for model estimation. The summarized output is transformed back to correlations (apart from the heterogeneity parameter tau that is always summarized on the transformed scale). One-sided p-values can be supplied as an optional input, if not provided, the p-values are computed using from the given correlation coefficients and sample sizes.
 
 #### Data
 - Effect Size: Effect sizes of the studies.
 - Effect Size Standard Error: Standard errors of the effect sizes per study. Must always be positive.
-- N: Overall sample sizes of the studies. Only possible if the studies effect sizes are correlations.
+- N: Overall sample sizes of the studies. Only possible if the supplied effect sizes are correlations.
 - P-value (one-sided): One-sided p-values of the studies (optional, if not provided, the p-values are computed based on the rest of input.)
 
 
@@ -23,17 +23,17 @@ The selection models allow the user to specify a publication bias adjusted rando
 - Expected effect size direction: The direction of the expected effect size (the publication bias adjusted models are not symmetrical around zero due to the estimation of weights).
 - Two-sided selection: Whether the specified p-values cutoffs correspond to one-sided or two-sided values. Note that the two-sided p-values cutoffs are internally transformed into one-sided p-values cutoffs with different weights at each side of the p-value distribution.
 - Automatically join p-value intervals: Automatically joins p-value intervals with fewer than 4 p-values to reduce estimation issues.
-- Transform correlations: Type of transformation to be applied prior to estimating models when correlation coefficients are supplied as input. The resulting mean estimates and figures display mean estimates transformed back to the correlation scale. The heterogeneity estimates are summarized on the transformed scale.
+- Transform correlations: Type of transformation to be applied prior to estimating models when correlation coefficients are supplied as input. The estimates and figures display mean estimates transformed back to the correlation scale (apart from the heterogeneity parameter tau that is always summarized on the transformed scale).
 
 
 ### Inference
 ---
 #### Fixed Effects
-- Mean estimates: Summarizes mean estimates of the non-adjusted and adjusted fixed effects models.
+- Mean estimates: Summarizes mean effect size estimates of the non-adjusted and adjusted fixed effects models.
 - Estimated weights: Summarizes estimated publication bias weights of the adjusted fixed effects model.
 
 #### Random Effects
-- Mean estimates: Summarizes mean estimates of the non-adjusted and adjusted fixed effects models.
+- Mean estimates: Summarizes mean effect size estimates of the non-adjusted and adjusted fixed effects models.
 - Estimated heterogeneity: Summarizes heterogeneity estimates of the non-adjusted and adjusted random effects models.
 - Estimated weights: Summarizes estimated publication bias weights of the adjusted random effects model.
 
@@ -47,11 +47,14 @@ Visualizes the estimated publication bias weights as a weight function.
   - Rescale x-axis: Make the differences between the individual ticks on x-axis equal for easier interpretability.
 
 #### Mean model estimates
-Visualizes mean estimates from all fitted models.
+Visualizes mean effect size estimates from all fitted models.
 
 
 ### References
 ---
+Iyengar, S., & Greenhouse, J. B. (1988). Selection models and the file drawer problem. Statistical Science, 109-117.
+
+Vevea, J. L., & Hedges, L. V. (1995). A general linear model for estimating effect size in the presence of publication bias. Psychometrika, 60(3), 419-435.
 
 
 ### R-packages

--- a/inst/help/waapwlspetpeese.md
+++ b/inst/help/waapwlspetpeese.md
@@ -1,0 +1,63 @@
+WAAP-WLS and PET-PEESE
+===
+
+The WAAP-WLS and PET-PEESE are meta-analytic methods based on weighted least squares. Instead of the classical (random or fixed) meta-analyses that assume additive heterogeneity, WAAP-WLS and PET-PEESE assume multiplicative heterogeneity. Furthermore, WAAP, PET, and PEESE incorporate different adjustments of selection processes. See Carter et al. (2019) for an overview of the methods.
+- WLS is the default meta-analytic model that assumes multiplicative heterogeneity (Stanley & Doucouliagos, 2017).
+- WAAP adjusts for selection processes by using only high-powered studies -- a WLS model fitted only with studies that would have at least 80% power to detect the WLS meta-analytic effect size estimate based on all studies (Ioannidis, Stanley, & Doucouliagos, 2017; Stanley et al., 2017).
+- PET adjusts for selection processes by adjusting for the relationship between effect sizes and standard errors (Stanley & Doucouliagos, 2014; Stanley, 2017).
+- PEESE adjusts for selection processes by adjusting for the relationship between effect sizes and standard errors squared (Stanley & Doucouliagos, 2014; Stanley, 2017).
+
+WAAP-WLS and PET-PEESE are usually used as conditional estimators. In WAAP-WLS, WAAP is used if there are enough (at least 3) highly powered studies, otherwise WLS is used (Ioannidis, Stanley, & Doucouliagos, 2017; Stanley et al., 2017). In PET-PEESE, PET is used to test for the presence of the effect size with alpha = 0.10, the PEESE effect size estimate is used if the PET's test for effect size is significant, otherwise PET effect size estimate is used (Stanley & Doucouliagos, 2014; Stanley, 2017).
+
+### Input
+---
+#### Input type
+- Effect sizes & SE: Specifying input using any other types of effect sizes and standard errors.
+- Correlations & N: Specifying input using correlations and the sample size. Note that the effect size is internally transformed to Fisher's z scale for model estimation. The summarized output is transformed back to correlations.
+
+#### Data
+- Effect Size: Effect sizes of the studies.
+- Effect Size Standard Error: Standard errors of the effect sizes per study. Must always be positive.
+- N: Overall sample sizes of the studies. Only possible if the supplied effect sizes are correlations.
+- Transform correlations: Type of transformation to be applied prior to estimating models when correlation coefficients are supplied as input. The estimates and figures display mean estimates transformed back to the correlation scale (apart from the meta-regression estimates for the standard error /standard errors squared).
+
+
+### Inference
+---
+#### Mean Estimates
+Summarizes the mean effect size estimates.
+
+#### PET-PEESE Regression Estimates
+Summarizes the regression coefficients of the relationship between effect sizes and standard errors (PET) and effect sizes and standard errors squared (PEESE).
+
+#### Multiplicative Heterogeneity Estimates
+Summarizes the multiplicative heterogeneity estimates.
+
+
+### Plots
+---
+#### Meta-Regression Estimate
+Visualizes the estimated meta-regression of the relationship between the effect sizes and standard errors.
+
+#### Mean model estimates
+Visualizes mean effect size estimates from all fitted models.
+
+
+### References
+---
+Carter, E. C., Schönbrodt, F. D., Gervais, W. M., & Hilgard, J. (2019). Correcting for bias in psychology: A comparison of meta-analytic methods. Advances in Methods and Practices in Psychological Science, 2(2), 115-144.
+
+Ioannidis, J. P., Stanley, T. D., & Doucouliagos, H. (2017). The power of bias in economics research.
+
+Stanley, T. D., Doucouliagos, H., & Ioannidis, J. P. (2017). Finding the power to reduce publication bias.Statistics in medicine, 36(10), 1580-1598.
+
+Stanley, T. D., & Doucouliagos, H. (2014). Meta‐regression approximations to reduce publication selection bias. Research Synthesis Methods, 5(1), 60-78.
+
+Stanley, T. D., & Doucouliagos, H. (2017). Neither fixed nor random: weighted least squares meta‐regression. Research synthesis methods, 8(1), 19-42.
+
+Stanley, T. D. (2017). Limitations of PET-PEESE and other meta-analysis methods. Social Psychological and Personality Science, 8(5), 581-591.
+
+
+### R-packages
+---
+The implementation is based on the supplementary materials of Carter et al., (2019).

--- a/inst/qml/WaapWlsPetPeese.qml
+++ b/inst/qml/WaapWlsPetPeese.qml
@@ -1,0 +1,164 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
+
+Form
+{
+
+	RadioButtonGroup
+	{
+		Layout.columnSpan:		2
+		name:					"measures"
+		radioButtonsOnSameRow:	true
+		columns:				2
+
+		RadioButton
+		{
+			label: qsTr("Effect sizes & SE")
+			value: "general"
+			id: 	measuresGeneral
+			checked:true
+		}
+
+		RadioButton
+		{
+			label: qsTr("Correlations & N")
+			value: "correlation"
+			id: 	measuresCorrelation
+		}
+	}
+
+	VariablesForm
+	{
+		preferredHeight: 200 * preferencesModel.uiScale
+
+		AvailableVariablesList
+		{
+			name: "allVariables"
+		}
+
+		AssignedVariablesList
+		{
+			name:			"inputES"
+			title:
+			{
+				if (measuresCorrelation.checked)
+					qsTr("Correlation")
+				else
+					qsTr("Effect Size")
+			}
+			singleVariable:	true
+			allowedColumns:	["scale"]
+		}
+
+		AssignedVariablesList
+		{
+			name:			"inputSE"
+			title:			qsTr("Effect Size Standard Error")
+			singleVariable:	true
+			allowedColumns:	["scale"]
+			visible:		 measuresGeneral.checked
+			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
+		}
+
+		AssignedVariablesList
+		{
+			name: 			"inputN"
+			title: 			qsTr("N")
+			singleVariable: true
+			allowedColumns: ["scale", "ordinal"]
+			visible:		 measuresCorrelation.checked
+			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
+		}
+
+		DropDown
+		{
+			visible:	measuresCorrelation.checked
+			label:		qsTr("Transform correlations")
+			name:		"muTransform"
+			values:
+			[
+				{ label: qsTr("Fisher's z"),	value: "fishersZ"},
+				{ label: qsTr("Cohen's d"),		value: "cohensD"}
+			]
+		}
+	}
+
+
+	Section
+	{
+		title: qsTr("Inference")
+		
+		Group
+		{
+			CheckBox
+			{
+				text:		qsTr("Mean estimates")
+				name:		"estimatesMean"
+				checked:	true
+			}
+						
+			CheckBox
+			{
+				text:		qsTr("PET-PEESE regression estimates")
+				name:		"estimatesPetPeese"
+				checked:	false
+			}
+
+			CheckBox
+			{
+				text:		qsTr("Multiplicative heterogeneity estimates")
+				name:		"estimatesSigma"
+				checked:	false
+			}
+		}
+	}
+
+	Section
+	{
+		title: qsTr("Plots")
+
+		Group
+		{
+			title: qsTr("Meta-Regression Estimate")
+
+			CheckBox
+			{
+				text:	qsTr("PET")
+				name:	"regressionPet"
+			}
+
+			CheckBox
+			{
+				text:	qsTr("PEESE")
+				name:	"regressionPeese"
+			}
+		}
+
+		CheckBox
+		{
+			text:	qsTr("Mean model estimates")
+			name:	"plotModels"
+		}
+
+	}
+}

--- a/tests/testthat/_snaps/waapwlspetpeese/test1-estimated-peese-regression.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test1-estimated-peese-regression.svg
@@ -1,0 +1,173 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpNjMuODF8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
+    <rect x='63.81' y='20.71' width='656.19' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjMuODF8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
+<rect x='63.81' y='20.71' width='656.19' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polygon points='93.64,281.80 99.60,281.78 105.57,281.75 111.54,281.70 117.50,281.64 123.47,281.59 129.43,281.55 135.40,281.56 141.36,281.63 147.33,281.78 153.29,282.06 159.26,282.49 165.22,283.10 171.19,283.91 177.15,284.93 183.12,286.17 189.08,287.62 195.05,289.29 201.02,291.17 206.98,293.25 212.95,295.51 218.91,297.96 224.88,300.58 230.84,303.37 236.81,306.32 242.77,309.44 248.74,312.71 254.70,316.13 260.67,319.70 266.63,323.42 272.60,327.28 278.56,331.29 284.53,335.45 290.50,339.74 296.46,344.18 302.43,348.76 308.39,353.47 314.36,358.33 320.32,363.32 326.29,368.46 332.25,373.73 338.22,379.14 344.18,384.68 350.15,390.36 356.11,396.18 362.08,402.14 368.04,408.23 374.01,414.46 379.98,420.82 385.94,427.32 391.91,433.96 397.87,440.73 403.84,447.64 409.80,454.68 415.77,461.86 421.73,469.17 427.70,476.62 433.66,484.20 439.63,491.92 445.59,499.77 451.56,507.76 457.52,515.89 463.49,524.15 469.46,532.54 475.42,541.07 481.39,549.73 487.35,558.53 493.32,567.46 499.28,576.53 505.25,585.74 511.21,595.07 517.18,604.55 523.14,614.15 529.11,623.90 535.07,633.77 541.04,643.78 547.01,653.93 552.97,664.21 558.94,674.63 564.90,685.18 570.87,695.86 576.83,706.68 582.80,717.64 588.76,728.72 594.73,739.95 600.69,751.31 606.66,762.80 612.62,774.43 618.59,786.19 624.55,798.08 630.52,810.11 636.49,822.28 642.45,834.58 648.42,847.01 654.38,859.58 660.35,872.29 666.31,885.12 672.28,898.10 678.24,911.20 684.21,924.45 690.17,937.82 690.17,-246.28 684.21,-235.95 678.24,-225.71 672.28,-215.58 666.31,-205.56 660.35,-195.64 654.38,-185.82 648.42,-176.11 642.45,-166.50 636.49,-157.00 630.52,-147.59 624.55,-138.30 618.59,-129.10 612.62,-120.02 606.66,-111.03 600.69,-102.15 594.73,-93.37 588.76,-84.70 582.80,-76.13 576.83,-67.67 570.87,-59.31 564.90,-51.05 558.94,-42.90 552.97,-34.85 547.01,-26.91 541.04,-19.07 535.07,-11.33 529.11,-3.70 523.14,3.83 517.18,11.25 511.21,18.57 505.25,25.78 499.28,32.90 493.32,39.90 487.35,46.80 481.39,53.60 475.42,60.30 469.46,66.88 463.49,73.37 457.52,79.75 451.56,86.03 445.59,92.20 439.63,98.26 433.66,104.23 427.70,110.08 421.73,115.84 415.77,121.48 409.80,127.03 403.84,132.47 397.87,137.80 391.91,143.03 385.94,148.15 379.98,153.17 374.01,158.08 368.04,162.89 362.08,167.59 356.11,172.19 350.15,176.68 344.18,181.06 338.22,185.34 332.25,189.51 326.29,193.58 320.32,197.53 314.36,201.38 308.39,205.12 302.43,208.76 296.46,212.28 290.50,215.69 284.53,219.00 278.56,222.19 272.60,225.27 266.63,228.23 260.67,231.08 254.70,233.81 248.74,236.42 242.77,238.91 236.81,241.28 230.84,243.51 224.88,245.62 218.91,247.58 212.95,249.40 206.98,251.07 201.02,252.58 195.05,253.92 189.08,255.09 183.12,256.07 177.15,256.87 171.19,257.48 165.22,257.90 159.26,258.16 153.29,258.27 147.33,258.26 141.36,258.16 135.40,257.99 129.43,257.80 123.47,257.59 117.50,257.40 111.54,257.24 105.57,257.11 99.60,257.03 93.64,257.01 ' style='stroke-width: 1.07; stroke: none; fill: #CCCCCC;' />
+<polyline points='93.64,269.40 99.60,269.41 105.57,269.43 111.54,269.47 117.50,269.52 123.47,269.59 129.43,269.68 135.40,269.78 141.36,269.89 147.33,270.02 153.29,270.17 159.26,270.33 165.22,270.50 171.19,270.69 177.15,270.90 183.12,271.12 189.08,271.36 195.05,271.61 201.02,271.88 206.98,272.16 212.95,272.46 218.91,272.77 224.88,273.10 230.84,273.44 236.81,273.80 242.77,274.17 248.74,274.56 254.70,274.97 260.67,275.39 266.63,275.82 272.60,276.27 278.56,276.74 284.53,277.22 290.50,277.72 296.46,278.23 302.43,278.76 308.39,279.30 314.36,279.86 320.32,280.43 326.29,281.02 332.25,281.62 338.22,282.24 344.18,282.87 350.15,283.52 356.11,284.19 362.08,284.87 368.04,285.56 374.01,286.27 379.98,287.00 385.94,287.74 391.91,288.49 397.87,289.27 403.84,290.05 409.80,290.85 415.77,291.67 421.73,292.50 427.70,293.35 433.66,294.21 439.63,295.09 445.59,295.99 451.56,296.89 457.52,297.82 463.49,298.76 469.46,299.71 475.42,300.68 481.39,301.67 487.35,302.67 493.32,303.68 499.28,304.71 505.25,305.76 511.21,306.82 517.18,307.90 523.14,308.99 529.11,310.10 535.07,311.22 541.04,312.36 547.01,313.51 552.97,314.68 558.94,315.86 564.90,317.06 570.87,318.28 576.83,319.51 582.80,320.75 588.76,322.01 594.73,323.29 600.69,324.58 606.66,325.88 612.62,327.20 618.59,328.54 624.55,329.89 630.52,331.26 636.49,332.64 642.45,334.04 648.42,335.45 654.38,336.88 660.35,338.32 666.31,339.78 672.28,341.26 678.24,342.75 684.21,344.25 690.17,345.77 ' style='stroke-width: 2.67; stroke-linecap: butt;' />
+<polygon points='137.74,209.12 140.23,206.63 142.72,209.12 140.23,211.60 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='190.25,371.86 192.73,369.38 195.22,371.86 192.73,374.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='161.34,176.78 163.83,174.29 166.32,176.78 163.83,179.27 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='170.57,211.51 173.06,209.02 175.55,211.51 173.06,214.00 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='161.80,293.34 164.28,290.85 166.77,293.34 164.28,295.82 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='239.00,339.27 241.49,336.78 243.98,339.27 241.49,341.76 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='182.41,300.10 184.89,297.61 187.38,300.10 184.89,302.59 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='111.92,305.43 114.41,302.95 116.90,305.43 114.41,307.92 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='113.74,246.76 116.23,244.27 118.72,246.76 116.23,249.25 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='256.87,301.22 259.35,298.74 261.84,301.22 259.35,303.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='328.39,243.74 330.88,241.25 333.37,243.74 330.88,246.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='249.63,234.83 252.12,232.34 254.61,234.83 252.12,237.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='117.51,316.66 119.99,314.17 122.48,316.66 119.99,319.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='131.60,285.96 134.09,283.47 136.57,285.96 134.09,288.44 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='242.09,393.06 244.57,390.57 247.06,393.06 244.57,395.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='288.37,298.88 290.85,296.39 293.34,298.88 290.85,301.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='204.51,231.36 207.00,228.88 209.48,231.36 207.00,233.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='196.21,242.25 198.70,239.76 201.18,242.25 198.70,244.74 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='228.03,333.76 230.52,331.28 233.01,333.76 230.52,336.25 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='147.39,205.39 149.88,202.90 152.37,205.39 149.88,207.88 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='260.18,310.90 262.67,308.41 265.16,310.90 262.67,313.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='200.87,283.77 203.35,281.29 205.84,283.77 203.35,286.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='394.08,257.88 396.57,255.39 399.05,257.88 396.57,260.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='173.66,263.30 176.15,260.81 178.63,263.30 176.15,265.78 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='122.59,112.49 125.08,110.01 127.57,112.49 125.08,114.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='366.63,296.92 369.12,294.43 371.61,296.92 369.12,299.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='398.84,289.89 401.33,287.40 403.81,289.89 401.33,292.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='232.14,343.90 234.62,341.41 237.11,343.90 234.62,346.39 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='260.49,235.98 262.98,233.49 265.46,235.98 262.98,238.47 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='130.53,246.90 133.01,244.41 135.50,246.90 133.01,249.39 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='325.64,341.03 328.13,338.54 330.62,341.03 328.13,343.52 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='224.23,284.24 226.71,281.75 229.20,284.24 226.71,286.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='160.39,220.06 162.88,217.57 165.36,220.06 162.88,222.55 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='102.92,230.95 105.41,228.46 107.90,230.95 105.41,233.44 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='131.52,294.68 134.00,292.19 136.49,294.68 134.00,297.17 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='387.97,228.30 390.46,225.81 392.95,228.30 390.46,230.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='256.67,277.32 259.16,274.83 261.65,277.32 259.16,279.81 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='182.55,185.97 185.03,183.48 187.52,185.97 185.03,188.46 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='327.35,282.84 329.84,280.36 332.33,282.84 329.84,285.33 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='150.30,298.07 152.79,295.59 155.28,298.07 152.79,300.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='134.24,302.19 136.73,299.70 139.22,302.19 136.73,304.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='127.80,342.13 130.29,339.64 132.78,342.13 130.29,344.62 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='119.98,307.35 122.47,304.86 124.95,307.35 122.47,309.84 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='231.88,310.38 234.37,307.89 236.86,310.38 234.37,312.87 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='195.59,319.12 198.08,316.63 200.57,319.12 198.08,321.61 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='348.96,208.23 351.45,205.74 353.94,208.23 351.45,210.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='162.46,297.71 164.95,295.22 167.44,297.71 164.95,300.20 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='269.16,237.96 271.65,235.47 274.13,237.96 271.65,240.45 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='115.63,431.04 118.12,428.55 120.60,431.04 118.12,433.53 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='109.19,254.68 111.68,252.19 114.17,254.68 111.68,257.17 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='120.65,300.29 123.14,297.80 125.63,300.29 123.14,302.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='133.86,355.09 136.35,352.61 138.83,355.09 136.35,357.58 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='167.58,222.04 170.07,219.55 172.56,222.04 170.07,224.53 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='256.73,286.72 259.21,284.23 261.70,286.72 259.21,289.21 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='189.24,78.41 191.73,75.92 194.22,78.41 191.73,80.89 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='225.29,300.21 227.78,297.72 230.27,300.21 227.78,302.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='346.45,249.51 348.94,247.02 351.42,249.51 348.94,251.99 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='141.82,258.80 144.31,256.32 146.80,258.80 144.31,261.29 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='191.45,268.15 193.94,265.66 196.43,268.15 193.94,270.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='244.07,248.19 246.56,245.70 249.05,248.19 246.56,250.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='166.02,210.17 168.51,207.68 170.99,210.17 168.51,212.66 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='170.67,339.93 173.16,337.44 175.65,339.93 173.16,342.42 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='179.34,353.86 181.83,351.37 184.31,353.86 181.83,356.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='250.72,143.44 253.20,140.95 255.69,143.44 253.20,145.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='116.97,243.11 119.46,240.62 121.94,243.11 119.46,245.60 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='251.76,327.14 254.25,324.65 256.74,327.14 254.25,329.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='142.62,159.49 145.11,157.00 147.60,159.49 145.11,161.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='329.75,254.15 332.24,251.66 334.73,254.15 332.24,256.64 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='369.20,300.81 371.69,298.32 374.18,300.81 371.69,303.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='386.38,232.36 388.86,229.87 391.35,232.36 388.86,234.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='198.07,312.64 200.56,310.16 203.05,312.64 200.56,315.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='131.90,308.22 134.39,305.73 136.88,308.22 134.39,310.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='111.61,270.59 114.10,268.10 116.59,270.59 114.10,273.08 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='212.22,315.73 214.71,313.24 217.19,315.73 214.71,318.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='224.24,383.07 226.73,380.59 229.22,383.07 226.73,385.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='198.57,239.51 201.06,237.02 203.55,239.51 201.06,242.00 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='168.37,303.31 170.86,300.82 173.35,303.31 170.86,305.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='146.90,236.09 149.39,233.60 151.88,236.09 149.39,238.57 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='614.21,338.66 616.70,336.18 619.19,338.66 616.70,341.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='299.43,249.57 301.92,247.08 304.41,249.57 301.92,252.05 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='234.50,315.54 236.99,313.06 239.48,315.54 236.99,318.03 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='193.24,235.26 195.73,232.77 198.22,235.26 195.73,237.75 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='137.75,100.36 140.23,97.88 142.72,100.36 140.23,102.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='158.28,270.47 160.77,267.98 163.25,270.47 160.77,272.96 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='117.12,308.44 119.61,305.95 122.10,308.44 119.61,310.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='224.56,269.21 227.05,266.72 229.53,269.21 227.05,271.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='129.11,250.66 131.60,248.17 134.09,250.66 131.60,253.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='441.31,274.92 443.80,272.44 446.29,274.92 443.80,277.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='166.80,308.45 169.29,305.96 171.77,308.45 169.29,310.94 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='193.21,303.03 195.70,300.54 198.19,303.03 195.70,305.52 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='197.84,353.72 200.33,351.24 202.82,353.72 200.33,356.21 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='169.58,299.77 172.07,297.28 174.56,299.77 172.07,302.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='212.55,266.72 215.04,264.23 217.53,266.72 215.04,269.21 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='275.90,287.84 278.39,285.35 280.87,287.84 278.39,290.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='140.10,285.94 142.59,283.45 145.08,285.94 142.59,288.43 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='421.62,245.25 424.10,242.76 426.59,245.25 424.10,247.74 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='123.38,287.92 125.87,285.43 128.36,287.92 125.87,290.40 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='119.74,288.44 122.23,285.95 124.72,288.44 122.23,290.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='271.02,320.87 273.51,318.38 276.00,320.87 273.51,323.36 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='164.90,233.80 167.39,231.32 169.88,233.80 167.39,236.29 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<line x1='93.32' y1='507.09' x2='690.49' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='63.81' y1='485.30' x2='63.81' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='63.81' y='20.71' width='656.19' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='63.81,507.09 63.81,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='48.33' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text x='48.33' y='435.56' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='48.33' y='380.29' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='48.33' y='325.02' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='48.33' y='269.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='48.33' y='214.48' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='48.33' y='159.21' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='48.33' y='103.94' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='48.33' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='55.31,484.99 63.81,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,429.71 63.81,429.71 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,374.44 63.81,374.44 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,319.17 63.81,319.17 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,263.90 63.81,263.90 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,208.63 63.81,208.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,153.36 63.81,153.36 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,98.09 63.81,98.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,42.82 63.81,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.81,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='93.64,515.60 93.64,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='212.95,515.60 212.95,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='332.25,515.60 332.25,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='451.56,515.60 451.56,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='570.87,515.60 570.87,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='690.17,515.60 690.17,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='93.64' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='212.95' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='332.25' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='451.56' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='570.87' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='690.17' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='391.91' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='133.81px' lengthAdjust='spacingAndGlyphs'>Standard Error</text>
+<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='97.53px' lengthAdjust='spacingAndGlyphs'>Effect Size</text>
+<text x='391.91' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='253.28px' lengthAdjust='spacingAndGlyphs'>test1-estimated-peese-regression</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test1-estimated-pet-regression.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test1-estimated-pet-regression.svg
@@ -1,0 +1,173 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpNjMuODF8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
+    <rect x='63.81' y='20.71' width='656.19' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjMuODF8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
+<rect x='63.81' y='20.71' width='656.19' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polygon points='93.64,284.32 99.60,283.31 105.57,282.45 111.54,281.79 117.50,281.40 123.47,281.32 129.43,281.61 135.40,282.28 141.36,283.32 147.33,284.68 153.29,286.32 159.26,288.16 165.22,290.16 171.19,292.29 177.15,294.51 183.12,296.80 189.08,299.15 195.05,301.54 201.02,303.97 206.98,306.42 212.95,308.90 218.91,311.40 224.88,313.92 230.84,316.44 236.81,318.98 242.77,321.53 248.74,324.09 254.70,326.65 260.67,329.23 266.63,331.80 272.60,334.39 278.56,336.97 284.53,339.56 290.50,342.16 296.46,344.75 302.43,347.35 308.39,349.95 314.36,352.56 320.32,355.16 326.29,357.77 332.25,360.38 338.22,362.99 344.18,365.61 350.15,368.22 356.11,370.84 362.08,373.45 368.04,376.07 374.01,378.69 379.98,381.31 385.94,383.93 391.91,386.55 397.87,389.17 403.84,391.80 409.80,394.42 415.77,397.05 421.73,399.67 427.70,402.30 433.66,404.92 439.63,407.55 445.59,410.17 451.56,412.80 457.52,415.43 463.49,418.06 469.46,420.68 475.42,423.31 481.39,425.94 487.35,428.57 493.32,431.20 499.28,433.83 505.25,436.46 511.21,439.09 517.18,441.72 523.14,444.35 529.11,446.98 535.07,449.61 541.04,452.25 547.01,454.88 552.97,457.51 558.94,460.14 564.90,462.77 570.87,465.41 576.83,468.04 582.80,470.67 588.76,473.30 594.73,475.94 600.69,478.57 606.66,481.20 612.62,483.84 618.59,486.47 624.55,489.10 630.52,491.74 636.49,494.37 642.45,497.00 648.42,499.64 654.38,502.27 660.35,504.91 666.31,507.54 672.28,510.18 678.24,512.81 684.21,515.44 690.17,518.08 690.17,116.47 684.21,118.10 678.24,119.73 672.28,121.35 666.31,122.98 660.35,124.60 654.38,126.23 648.42,127.85 642.45,129.48 636.49,131.11 630.52,132.73 624.55,134.36 618.59,135.98 612.62,137.61 606.66,139.23 600.69,140.86 594.73,142.48 588.76,144.11 582.80,145.73 576.83,147.35 570.87,148.98 564.90,150.60 558.94,152.23 552.97,153.85 547.01,155.47 541.04,157.10 535.07,158.72 529.11,160.34 523.14,161.96 517.18,163.59 511.21,165.21 505.25,166.83 499.28,168.45 493.32,170.07 487.35,171.69 481.39,173.32 475.42,174.94 469.46,176.56 463.49,178.18 457.52,179.79 451.56,181.41 445.59,183.03 439.63,184.65 433.66,186.27 427.70,187.89 421.73,189.50 415.77,191.12 409.80,192.73 403.84,194.35 397.87,195.96 391.91,197.58 385.94,199.19 379.98,200.80 374.01,202.41 368.04,204.02 362.08,205.63 356.11,207.24 350.15,208.85 344.18,210.46 338.22,212.06 332.25,213.66 326.29,215.27 320.32,216.87 314.36,218.46 308.39,220.06 302.43,221.65 296.46,223.24 290.50,224.83 284.53,226.42 278.56,228.00 272.60,229.58 266.63,231.15 260.67,232.72 254.70,234.28 248.74,235.84 242.77,237.39 236.81,238.93 230.84,240.46 224.88,241.98 218.91,243.49 212.95,244.98 206.98,246.45 201.02,247.89 195.05,249.31 189.08,250.70 183.12,252.04 177.15,253.32 171.19,254.53 165.22,255.65 159.26,256.64 153.29,257.48 147.33,258.10 141.36,258.46 135.40,258.49 129.43,258.15 123.47,257.43 117.50,256.34 111.54,254.94 105.57,253.28 99.60,251.41 93.64,249.39 ' style='stroke-width: 1.07; stroke: none; fill: #CCCCCC;' />
+<polyline points='93.64,266.85 99.60,267.36 105.57,267.86 111.54,268.37 117.50,268.87 123.47,269.38 129.43,269.88 135.40,270.38 141.36,270.89 147.33,271.39 153.29,271.90 159.26,272.40 165.22,272.91 171.19,273.41 177.15,273.91 183.12,274.42 189.08,274.92 195.05,275.43 201.02,275.93 206.98,276.43 212.95,276.94 218.91,277.44 224.88,277.95 230.84,278.45 236.81,278.96 242.77,279.46 248.74,279.96 254.70,280.47 260.67,280.97 266.63,281.48 272.60,281.98 278.56,282.49 284.53,282.99 290.50,283.49 296.46,284.00 302.43,284.50 308.39,285.01 314.36,285.51 320.32,286.01 326.29,286.52 332.25,287.02 338.22,287.53 344.18,288.03 350.15,288.54 356.11,289.04 362.08,289.54 368.04,290.05 374.01,290.55 379.98,291.06 385.94,291.56 391.91,292.07 397.87,292.57 403.84,293.07 409.80,293.58 415.77,294.08 421.73,294.59 427.70,295.09 433.66,295.59 439.63,296.10 445.59,296.60 451.56,297.11 457.52,297.61 463.49,298.12 469.46,298.62 475.42,299.12 481.39,299.63 487.35,300.13 493.32,300.64 499.28,301.14 505.25,301.65 511.21,302.15 517.18,302.65 523.14,303.16 529.11,303.66 535.07,304.17 541.04,304.67 547.01,305.17 552.97,305.68 558.94,306.18 564.90,306.69 570.87,307.19 576.83,307.70 582.80,308.20 588.76,308.70 594.73,309.21 600.69,309.71 606.66,310.22 612.62,310.72 618.59,311.23 624.55,311.73 630.52,312.23 636.49,312.74 642.45,313.24 648.42,313.75 654.38,314.25 660.35,314.75 666.31,315.26 672.28,315.76 678.24,316.27 684.21,316.77 690.17,317.28 ' style='stroke-width: 2.67; stroke-linecap: butt;' />
+<polygon points='137.74,209.12 140.23,206.63 142.72,209.12 140.23,211.60 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='190.25,371.86 192.73,369.38 195.22,371.86 192.73,374.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='161.34,176.78 163.83,174.29 166.32,176.78 163.83,179.27 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='170.57,211.51 173.06,209.02 175.55,211.51 173.06,214.00 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='161.80,293.34 164.28,290.85 166.77,293.34 164.28,295.82 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='239.00,339.27 241.49,336.78 243.98,339.27 241.49,341.76 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='182.41,300.10 184.89,297.61 187.38,300.10 184.89,302.59 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='111.92,305.43 114.41,302.95 116.90,305.43 114.41,307.92 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='113.74,246.76 116.23,244.27 118.72,246.76 116.23,249.25 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='256.87,301.22 259.35,298.74 261.84,301.22 259.35,303.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='328.39,243.74 330.88,241.25 333.37,243.74 330.88,246.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='249.63,234.83 252.12,232.34 254.61,234.83 252.12,237.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='117.51,316.66 119.99,314.17 122.48,316.66 119.99,319.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='131.60,285.96 134.09,283.47 136.57,285.96 134.09,288.44 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='242.09,393.06 244.57,390.57 247.06,393.06 244.57,395.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='288.37,298.88 290.85,296.39 293.34,298.88 290.85,301.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='204.51,231.36 207.00,228.88 209.48,231.36 207.00,233.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='196.21,242.25 198.70,239.76 201.18,242.25 198.70,244.74 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='228.03,333.76 230.52,331.28 233.01,333.76 230.52,336.25 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='147.39,205.39 149.88,202.90 152.37,205.39 149.88,207.88 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='260.18,310.90 262.67,308.41 265.16,310.90 262.67,313.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='200.87,283.77 203.35,281.29 205.84,283.77 203.35,286.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='394.08,257.88 396.57,255.39 399.05,257.88 396.57,260.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='173.66,263.30 176.15,260.81 178.63,263.30 176.15,265.78 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='122.59,112.49 125.08,110.01 127.57,112.49 125.08,114.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='366.63,296.92 369.12,294.43 371.61,296.92 369.12,299.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='398.84,289.89 401.33,287.40 403.81,289.89 401.33,292.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='232.14,343.90 234.62,341.41 237.11,343.90 234.62,346.39 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='260.49,235.98 262.98,233.49 265.46,235.98 262.98,238.47 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='130.53,246.90 133.01,244.41 135.50,246.90 133.01,249.39 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='325.64,341.03 328.13,338.54 330.62,341.03 328.13,343.52 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='224.23,284.24 226.71,281.75 229.20,284.24 226.71,286.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='160.39,220.06 162.88,217.57 165.36,220.06 162.88,222.55 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='102.92,230.95 105.41,228.46 107.90,230.95 105.41,233.44 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='131.52,294.68 134.00,292.19 136.49,294.68 134.00,297.17 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='387.97,228.30 390.46,225.81 392.95,228.30 390.46,230.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='256.67,277.32 259.16,274.83 261.65,277.32 259.16,279.81 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='182.55,185.97 185.03,183.48 187.52,185.97 185.03,188.46 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='327.35,282.84 329.84,280.36 332.33,282.84 329.84,285.33 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='150.30,298.07 152.79,295.59 155.28,298.07 152.79,300.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='134.24,302.19 136.73,299.70 139.22,302.19 136.73,304.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='127.80,342.13 130.29,339.64 132.78,342.13 130.29,344.62 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='119.98,307.35 122.47,304.86 124.95,307.35 122.47,309.84 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='231.88,310.38 234.37,307.89 236.86,310.38 234.37,312.87 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='195.59,319.12 198.08,316.63 200.57,319.12 198.08,321.61 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='348.96,208.23 351.45,205.74 353.94,208.23 351.45,210.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='162.46,297.71 164.95,295.22 167.44,297.71 164.95,300.20 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='269.16,237.96 271.65,235.47 274.13,237.96 271.65,240.45 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='115.63,431.04 118.12,428.55 120.60,431.04 118.12,433.53 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='109.19,254.68 111.68,252.19 114.17,254.68 111.68,257.17 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='120.65,300.29 123.14,297.80 125.63,300.29 123.14,302.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='133.86,355.09 136.35,352.61 138.83,355.09 136.35,357.58 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='167.58,222.04 170.07,219.55 172.56,222.04 170.07,224.53 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='256.73,286.72 259.21,284.23 261.70,286.72 259.21,289.21 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='189.24,78.41 191.73,75.92 194.22,78.41 191.73,80.89 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='225.29,300.21 227.78,297.72 230.27,300.21 227.78,302.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='346.45,249.51 348.94,247.02 351.42,249.51 348.94,251.99 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='141.82,258.80 144.31,256.32 146.80,258.80 144.31,261.29 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='191.45,268.15 193.94,265.66 196.43,268.15 193.94,270.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='244.07,248.19 246.56,245.70 249.05,248.19 246.56,250.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='166.02,210.17 168.51,207.68 170.99,210.17 168.51,212.66 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='170.67,339.93 173.16,337.44 175.65,339.93 173.16,342.42 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='179.34,353.86 181.83,351.37 184.31,353.86 181.83,356.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='250.72,143.44 253.20,140.95 255.69,143.44 253.20,145.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='116.97,243.11 119.46,240.62 121.94,243.11 119.46,245.60 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='251.76,327.14 254.25,324.65 256.74,327.14 254.25,329.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='142.62,159.49 145.11,157.00 147.60,159.49 145.11,161.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='329.75,254.15 332.24,251.66 334.73,254.15 332.24,256.64 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='369.20,300.81 371.69,298.32 374.18,300.81 371.69,303.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='386.38,232.36 388.86,229.87 391.35,232.36 388.86,234.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='198.07,312.64 200.56,310.16 203.05,312.64 200.56,315.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='131.90,308.22 134.39,305.73 136.88,308.22 134.39,310.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='111.61,270.59 114.10,268.10 116.59,270.59 114.10,273.08 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='212.22,315.73 214.71,313.24 217.19,315.73 214.71,318.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='224.24,383.07 226.73,380.59 229.22,383.07 226.73,385.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='198.57,239.51 201.06,237.02 203.55,239.51 201.06,242.00 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='168.37,303.31 170.86,300.82 173.35,303.31 170.86,305.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='146.90,236.09 149.39,233.60 151.88,236.09 149.39,238.57 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='614.21,338.66 616.70,336.18 619.19,338.66 616.70,341.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='299.43,249.57 301.92,247.08 304.41,249.57 301.92,252.05 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='234.50,315.54 236.99,313.06 239.48,315.54 236.99,318.03 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='193.24,235.26 195.73,232.77 198.22,235.26 195.73,237.75 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='137.75,100.36 140.23,97.88 142.72,100.36 140.23,102.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='158.28,270.47 160.77,267.98 163.25,270.47 160.77,272.96 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='117.12,308.44 119.61,305.95 122.10,308.44 119.61,310.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='224.56,269.21 227.05,266.72 229.53,269.21 227.05,271.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='129.11,250.66 131.60,248.17 134.09,250.66 131.60,253.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='441.31,274.92 443.80,272.44 446.29,274.92 443.80,277.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='166.80,308.45 169.29,305.96 171.77,308.45 169.29,310.94 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='193.21,303.03 195.70,300.54 198.19,303.03 195.70,305.52 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='197.84,353.72 200.33,351.24 202.82,353.72 200.33,356.21 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='169.58,299.77 172.07,297.28 174.56,299.77 172.07,302.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='212.55,266.72 215.04,264.23 217.53,266.72 215.04,269.21 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='275.90,287.84 278.39,285.35 280.87,287.84 278.39,290.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='140.10,285.94 142.59,283.45 145.08,285.94 142.59,288.43 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='421.62,245.25 424.10,242.76 426.59,245.25 424.10,247.74 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='123.38,287.92 125.87,285.43 128.36,287.92 125.87,290.40 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='119.74,288.44 122.23,285.95 124.72,288.44 122.23,290.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='271.02,320.87 273.51,318.38 276.00,320.87 273.51,323.36 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='164.90,233.80 167.39,231.32 169.88,233.80 167.39,236.29 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<line x1='93.32' y1='507.09' x2='690.49' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='63.81' y1='485.30' x2='63.81' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='63.81' y='20.71' width='656.19' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='63.81,507.09 63.81,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='48.33' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text x='48.33' y='435.56' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='48.33' y='380.29' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='48.33' y='325.02' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='48.33' y='269.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='48.33' y='214.48' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='48.33' y='159.21' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='48.33' y='103.94' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='48.33' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='55.31,484.99 63.81,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,429.71 63.81,429.71 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,374.44 63.81,374.44 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,319.17 63.81,319.17 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,263.90 63.81,263.90 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,208.63 63.81,208.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,153.36 63.81,153.36 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,98.09 63.81,98.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.31,42.82 63.81,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.81,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='93.64,515.60 93.64,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='212.95,515.60 212.95,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='332.25,515.60 332.25,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='451.56,515.60 451.56,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='570.87,515.60 570.87,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='690.17,515.60 690.17,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='93.64' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='212.95' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='332.25' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='451.56' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='570.87' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='690.17' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='391.91' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='133.81px' lengthAdjust='spacingAndGlyphs'>Standard Error</text>
+<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='97.53px' lengthAdjust='spacingAndGlyphs'>Effect Size</text>
+<text x='391.91' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='230.58px' lengthAdjust='spacingAndGlyphs'>test1-estimated-pet-regression</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test1-mean-model-estimates.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test1-mean-model-estimates.svg
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpMTA1LjQxfDcyMC4wMHwyMC43MXw1MDcuMDk='>
+    <rect x='105.41' y='20.71' width='614.59' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTA1LjQxfDcyMC4wMHwyMC43MXw1MDcuMDk=)'>
+<rect x='105.41' y='20.71' width='614.59' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polyline points='569.69,477.62 569.69,344.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='569.69,411.29 173.21,411.29 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='173.21,477.62 173.21,344.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='692.06,330.23 692.06,197.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='692.06,263.90 133.34,263.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='133.34,330.23 133.34,197.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='549.96,182.84 549.96,50.19 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='549.96,116.51 176.38,116.51 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='176.38,182.84 176.38,50.19 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polygon points='369.50,413.25 373.41,413.25 373.41,409.34 369.50,409.34 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='410.75,265.86 414.66,265.86 414.66,261.95 410.75,261.95 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='361.22,118.47 365.12,118.47 365.12,114.56 361.22,114.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polyline points='460.53,484.99 460.53,42.82 ' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<line x1='191.69' y1='507.09' x2='639.87' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='105.41' y='20.71' width='614.59' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='105.41,507.09 105.41,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='89.93' y='417.14' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='56.71px' lengthAdjust='spacingAndGlyphs'>PEESE</text>
+<text x='89.93' y='269.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.07px' lengthAdjust='spacingAndGlyphs'>PET</text>
+<text x='89.93' y='122.36' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='36.84px' lengthAdjust='spacingAndGlyphs'>WLS</text>
+<polyline points='105.41,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='192.01,515.60 192.01,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='281.52,515.60 281.52,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='371.03,515.60 371.03,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='460.53,515.60 460.53,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='550.04,515.60 550.04,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='639.55,515.60 639.55,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='192.01' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='29.29px' lengthAdjust='spacingAndGlyphs'>-0.3</text>
+<text x='281.52' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='29.29px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='371.03' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='29.29px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='460.53' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='550.04' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='639.55' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='412.70' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='177.30px' lengthAdjust='spacingAndGlyphs'>Mean Estimates (μ)</text>
+<text x='412.70' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='231.50px' lengthAdjust='spacingAndGlyphs'>test1-mean-model-estimates-î-</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test2-estimated-peese-regression.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test2-estimated-peese-regression.svg
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpODEuNzh8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
+    <rect x='81.78' y='20.71' width='638.22' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODEuNzh8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
+<rect x='81.78' y='20.71' width='638.22' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polygon points='110.79,432.72 116.60,432.69 122.40,432.61 128.20,432.48 134.00,432.29 139.80,432.05 145.61,431.75 151.41,431.41 157.21,431.00 163.01,430.55 168.81,430.04 174.62,429.47 180.42,428.86 186.22,428.19 192.02,427.46 197.82,426.68 203.63,425.85 209.43,424.97 215.23,424.03 221.03,423.04 226.83,421.99 232.64,420.89 238.44,419.74 244.24,418.53 250.04,417.27 255.84,415.96 261.65,414.60 267.45,413.18 273.25,411.71 279.05,410.18 284.85,408.60 290.66,406.97 296.46,405.29 302.26,403.55 308.06,401.76 313.86,399.92 319.67,398.02 325.47,396.07 331.27,394.07 337.07,392.02 342.87,389.92 348.67,387.76 354.48,385.55 360.28,383.29 366.08,380.98 371.88,378.62 377.68,376.21 383.49,373.75 389.29,371.24 395.09,368.68 400.89,366.08 406.69,363.43 412.50,360.73 418.30,357.98 424.10,355.20 429.90,352.37 435.70,349.50 441.51,346.60 447.31,343.66 453.11,340.70 458.91,337.72 464.71,334.73 470.52,331.74 476.32,328.77 482.12,325.84 487.92,323.00 493.72,320.30 499.53,317.82 505.33,315.73 511.13,314.23 516.93,313.67 522.73,314.42 528.54,316.72 534.34,320.51 540.14,325.50 545.94,331.34 551.74,337.78 557.55,344.66 563.35,351.86 569.15,359.32 574.95,366.99 580.75,374.84 586.56,382.86 592.36,391.03 598.16,399.33 603.96,407.77 609.76,416.34 615.56,425.02 621.37,433.83 627.17,442.75 632.97,451.79 638.77,460.93 644.57,470.19 650.38,479.56 656.18,489.03 661.98,498.61 667.78,508.30 673.58,518.10 679.39,528.00 685.19,538.01 690.99,548.12 690.99,160.43 685.19,165.77 679.39,171.05 673.58,176.28 667.78,181.44 661.98,186.55 656.18,191.59 650.38,196.58 644.57,201.51 638.77,206.38 632.97,211.18 627.17,215.92 621.37,220.59 615.56,225.20 609.76,229.73 603.96,234.20 598.16,238.58 592.36,242.88 586.56,247.09 580.75,251.19 574.95,255.19 569.15,259.04 563.35,262.73 557.55,266.21 551.74,269.42 545.94,272.24 540.14,274.50 534.34,275.96 528.54,276.27 522.73,275.14 516.93,272.51 511.13,268.61 505.33,263.83 499.53,258.49 493.72,252.83 487.92,246.98 482.12,241.04 476.32,235.07 470.52,229.10 464.71,223.16 458.91,217.26 453.11,211.43 447.31,205.66 441.51,199.96 435.70,194.35 429.90,188.82 424.10,183.38 418.30,178.02 412.50,172.76 406.69,167.59 400.89,162.51 395.09,157.53 389.29,152.64 383.49,147.85 377.68,143.16 371.88,138.57 366.08,134.07 360.28,129.67 354.48,125.37 348.67,121.18 342.87,117.08 337.07,113.08 331.27,109.18 325.47,105.38 319.67,101.68 313.86,98.08 308.06,94.58 302.26,91.18 296.46,87.89 290.66,84.69 284.85,81.59 279.05,78.60 273.25,75.71 267.45,72.91 261.65,70.22 255.84,67.63 250.04,65.15 244.24,62.76 238.44,60.47 232.64,58.29 226.83,56.21 221.03,54.22 215.23,52.34 209.43,50.57 203.63,48.89 197.82,47.31 192.02,45.84 186.22,44.47 180.42,43.20 174.62,42.03 168.81,40.96 163.01,40.00 157.21,39.13 151.41,38.37 145.61,37.71 139.80,37.15 134.00,36.69 128.20,36.34 122.40,36.08 116.60,35.93 110.79,35.88 ' style='stroke-width: 1.07; stroke: none; fill: #CCCCCC;' />
+<polyline points='110.79,234.30 116.60,234.31 122.40,234.35 128.20,234.41 134.00,234.49 139.80,234.60 145.61,234.73 151.41,234.89 157.21,235.07 163.01,235.27 168.81,235.50 174.62,235.75 180.42,236.03 186.22,236.33 192.02,236.65 197.82,237.00 203.63,237.37 209.43,237.77 215.23,238.19 221.03,238.63 226.83,239.10 232.64,239.59 238.44,240.11 244.24,240.65 250.04,241.21 255.84,241.80 261.65,242.41 267.45,243.05 273.25,243.71 279.05,244.39 284.85,245.10 290.66,245.83 296.46,246.59 302.26,247.37 308.06,248.17 313.86,249.00 319.67,249.85 325.47,250.72 331.27,251.62 337.07,252.55 342.87,253.50 348.67,254.47 354.48,255.46 360.28,256.48 366.08,257.53 371.88,258.60 377.68,259.69 383.49,260.80 389.29,261.94 395.09,263.11 400.89,264.29 406.69,265.51 412.50,266.74 418.30,268.00 424.10,269.29 429.90,270.59 435.70,271.92 441.51,273.28 447.31,274.66 453.11,276.06 458.91,277.49 464.71,278.94 470.52,280.42 476.32,281.92 482.12,283.44 487.92,284.99 493.72,286.56 499.53,288.16 505.33,289.78 511.13,291.42 516.93,293.09 522.73,294.78 528.54,296.50 534.34,298.24 540.14,300.00 545.94,301.79 551.74,303.60 557.55,305.43 563.35,307.29 569.15,309.18 574.95,311.09 580.75,313.02 586.56,314.97 592.36,316.95 598.16,318.96 603.96,320.98 609.76,323.04 615.56,325.11 621.37,327.21 627.17,329.33 632.97,331.48 638.77,333.65 644.57,335.85 650.38,338.07 656.18,340.31 661.98,342.58 667.78,344.87 673.58,347.19 679.39,349.53 685.19,351.89 690.99,354.28 ' style='stroke-width: 2.67; stroke-linecap: butt;' />
+<polygon points='525.94,388.92 528.43,386.43 530.92,388.92 528.43,391.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,350.17 516.02,347.68 518.51,350.17 516.02,352.65 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.37,276.36 502.85,273.87 505.34,276.36 502.85,278.84 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='561.36,149.88 563.85,147.40 566.34,149.88 563.85,152.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.55,411.99 515.04,409.51 517.52,411.99 515.04,414.48 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='533.73,153.65 536.21,151.17 538.70,153.65 536.21,156.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.73,135.84 525.22,133.35 527.71,135.84 525.22,138.33 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.71,243.61 494.20,241.12 496.69,243.61 494.20,246.10 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.94,255.44 528.43,252.95 530.92,255.44 528.43,257.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='544.41,462.29 546.90,459.80 549.38,462.29 546.90,464.78 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.73,410.45 525.22,407.96 527.71,410.45 525.22,412.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='530.34,421.05 532.82,418.57 535.31,421.05 532.82,423.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='495.10,233.79 497.59,231.31 500.08,233.79 497.59,236.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.54,345.79 520.03,343.30 522.52,345.79 520.03,348.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.08,202.62 505.57,200.13 508.06,202.62 505.57,205.10 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.54,304.13 520.03,301.64 522.52,304.13 520.03,306.62 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.53,222.31 519.02,219.82 521.51,222.31 519.02,224.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.83,117.56 499.32,115.07 501.81,117.56 499.32,120.05 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,347.28 495.88,344.79 498.37,347.28 495.88,349.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='539.56,199.74 542.05,197.25 544.54,199.74 542.05,202.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='497.71,139.69 500.20,137.20 502.68,139.69 500.20,142.18 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='549.42,408.22 551.91,405.73 554.40,408.22 551.91,410.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,247.02 517.01,244.53 519.50,247.02 517.01,249.51 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.37,439.41 502.85,436.92 505.34,439.41 502.85,441.90 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='494.25,388.30 496.74,385.81 499.22,388.30 496.74,390.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='532.59,345.06 535.08,342.57 537.56,345.06 535.08,347.55 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='549.42,479.61 551.91,477.12 554.40,479.61 551.91,482.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.79,346.42 526.28,343.93 528.77,346.42 526.28,348.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,164.65 516.02,162.16 518.51,164.65 516.02,167.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='505.85,361.74 508.34,359.26 510.83,361.74 508.34,364.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='544.41,309.88 546.90,307.39 549.38,309.88 546.90,312.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,266.44 516.02,263.95 518.51,266.44 516.02,268.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.79,305.66 526.28,303.18 528.77,305.66 526.28,308.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='507.73,417.57 510.22,415.08 512.71,417.57 510.22,420.06 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='538.38,180.79 540.86,178.30 543.35,180.79 540.86,183.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.96,240.74 544.45,238.26 546.94,240.74 544.45,243.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='537.20,193.38 539.69,190.89 542.18,193.38 539.69,195.87 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='558.63,445.73 561.11,443.24 563.60,445.73 561.11,448.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.96,220.02 544.45,217.53 546.94,220.02 544.45,222.50 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,335.86 495.88,333.37 498.37,335.86 495.88,338.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,183.24 523.12,180.75 525.61,183.24 523.12,185.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='548.15,248.75 550.64,246.26 553.13,248.75 550.64,251.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,197.66 516.02,195.17 518.51,197.66 516.02,200.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.54,283.70 520.03,281.21 522.52,283.70 520.03,286.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.68,292.32 524.17,289.83 526.66,292.32 524.17,294.81 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.08,195.23 505.57,192.74 508.06,195.23 505.57,197.72 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='501.26,476.05 503.75,473.56 506.24,476.05 503.75,478.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='554.61,311.67 557.10,309.18 559.59,311.67 557.10,314.16 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='505.85,216.78 508.34,214.29 510.83,216.78 508.34,219.27 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,231.65 517.01,229.17 519.50,231.65 517.01,234.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.52,311.52 518.01,309.04 520.50,311.52 518.01,314.01 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.52,167.89 518.01,165.40 520.50,167.89 518.01,170.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='492.55,326.04 495.04,323.55 497.53,326.04 495.04,328.53 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='551.99,396.42 554.48,393.93 556.97,396.42 554.48,398.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='546.89,459.10 549.38,456.61 551.87,459.10 549.38,461.59 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='531.46,448.78 533.95,446.29 536.43,448.78 533.95,451.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='529.22,370.50 531.71,368.01 534.20,370.50 531.71,372.99 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,296.41 495.88,293.93 498.37,296.41 495.88,298.90 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='553.30,243.16 555.78,240.67 558.27,243.16 555.78,245.65 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='557.28,337.49 559.76,335.00 562.25,337.49 559.76,339.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.79,148.09 526.28,145.60 528.77,148.09 526.28,150.58 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='479.74,378.73 482.23,376.25 484.72,378.73 482.23,381.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='505.85,318.34 508.34,315.85 510.83,318.34 508.34,320.83 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,364.64 523.12,362.15 525.61,364.64 523.12,367.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='509.64,247.32 512.12,244.83 514.61,247.32 512.12,249.81 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='539.56,391.63 542.05,389.14 544.54,391.63 542.05,394.12 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.94,311.18 528.43,308.70 530.92,311.18 528.43,313.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='568.43,203.95 570.92,201.46 573.41,203.95 570.92,206.44 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='580.46,454.24 582.95,451.75 585.44,454.24 582.95,456.72 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.68,162.49 524.17,160.01 526.66,162.49 524.17,164.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='543.18,362.21 545.67,359.72 548.16,362.21 545.67,364.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,176.20 517.01,173.71 519.50,176.20 517.01,178.69 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,359.44 523.12,356.95 525.61,359.44 523.12,361.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,364.14 495.88,361.65 498.37,364.14 495.88,366.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='510.60,311.99 513.09,309.50 515.58,311.99 513.09,314.48 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='538.38,156.03 540.86,153.54 543.35,156.03 540.86,158.52 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='532.59,166.69 535.08,164.21 537.56,166.69 535.08,169.18 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='549.42,343.64 551.91,341.15 554.40,343.64 551.91,346.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='509.64,199.79 512.12,197.30 514.61,199.79 512.12,202.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,129.68 517.01,127.19 519.50,129.68 517.01,132.17 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.68,327.30 511.17,324.81 513.66,327.30 511.17,329.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.73,224.23 525.22,221.74 527.71,224.23 525.22,226.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='527.03,339.99 529.51,337.50 532.00,339.99 529.51,342.48 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,367.20 523.12,364.71 525.61,367.20 523.12,369.69 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='527.03,207.44 529.51,204.95 532.00,207.44 529.51,209.92 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='495.10,411.63 497.59,409.14 500.08,411.63 497.59,414.12 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='558.63,224.75 561.11,222.26 563.60,224.75 561.11,227.24 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.55,440.79 515.04,438.31 517.52,440.79 515.04,443.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,396.17 495.88,393.68 498.37,396.17 495.88,398.66 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='504.92,433.03 507.41,430.54 509.90,433.03 507.41,435.51 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='565.56,398.29 568.05,395.80 570.54,398.29 568.05,400.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='504.00,463.31 506.48,460.82 508.97,463.31 506.48,465.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.68,250.53 524.17,248.04 526.66,250.53 524.17,253.02 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='494.25,162.13 496.74,159.64 499.22,162.13 496.74,164.62 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.55,199.18 515.04,196.70 517.52,199.18 515.04,201.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='502.17,192.21 504.66,189.73 507.15,192.21 504.66,194.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='559.99,319.73 562.48,317.25 564.96,319.73 562.48,322.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='536.03,336.30 538.52,333.81 541.01,336.30 538.52,338.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='519.60,187.07 522.08,184.58 524.57,187.07 522.08,189.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.86,264.44 527.35,261.96 529.84,264.44 527.35,266.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<line x1='110.48' y1='507.09' x2='691.31' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='81.78' y1='485.30' x2='81.78' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='81.78' y='20.71' width='638.22' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='81.78,507.09 81.78,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='66.31' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='66.31' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<text x='66.31' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.20</text>
+<text x='66.31' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='66.31' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.30</text>
+<text x='66.31' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.35</text>
+<polyline points='73.28,484.99 81.78,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,396.55 81.78,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,308.12 81.78,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,219.68 81.78,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,131.25 81.78,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,42.82 81.78,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='81.78,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='110.79,515.60 110.79,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='226.83,515.60 226.83,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='342.87,515.60 342.87,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='458.91,515.60 458.91,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='574.95,515.60 574.95,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='690.99,515.60 690.99,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='110.79' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='226.83' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.02</text>
+<text x='342.87' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.04</text>
+<text x='458.91' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.06</text>
+<text x='574.95' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.08</text>
+<text x='690.99' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='400.89' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='133.81px' lengthAdjust='spacingAndGlyphs'>Standard Error</text>
+<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='86.66px' lengthAdjust='spacingAndGlyphs'>Fisher's z</text>
+<text x='400.89' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='253.28px' lengthAdjust='spacingAndGlyphs'>test2-estimated-peese-regression</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test2-estimated-pet-regression.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test2-estimated-pet-regression.svg
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpODEuNzh8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
+    <rect x='81.78' y='20.71' width='638.22' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODEuNzh8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
+<rect x='81.78' y='20.71' width='638.22' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polygon points='110.79,583.38 116.60,579.33 122.40,575.29 128.20,571.24 134.00,567.20 139.80,563.15 145.61,559.11 151.41,555.06 157.21,551.02 163.01,546.98 168.81,542.93 174.62,538.89 180.42,534.85 186.22,530.80 192.02,526.76 197.82,522.72 203.63,518.68 209.43,514.64 215.23,510.60 221.03,506.56 226.83,502.52 232.64,498.48 238.44,494.44 244.24,490.40 250.04,486.36 255.84,482.33 261.65,478.29 267.45,474.25 273.25,470.22 279.05,466.19 284.85,462.15 290.66,458.12 296.46,454.09 302.26,450.06 308.06,446.03 313.86,442.00 319.67,437.98 325.47,433.95 331.27,429.93 337.07,425.91 342.87,421.89 348.67,417.88 354.48,413.86 360.28,409.85 366.08,405.84 371.88,401.84 377.68,397.84 383.49,393.84 389.29,389.85 395.09,385.86 400.89,381.88 406.69,377.91 412.50,373.95 418.30,369.99 424.10,366.05 429.90,362.12 435.70,358.20 441.51,354.30 447.31,350.43 453.11,346.58 458.91,342.77 464.71,339.00 470.52,335.30 476.32,331.66 482.12,328.13 487.92,324.74 493.72,321.56 499.53,318.68 505.33,316.26 511.13,314.54 516.93,313.85 522.73,314.57 528.54,316.86 534.34,320.58 540.14,325.36 545.94,330.87 551.74,336.86 557.55,343.15 563.35,349.66 569.15,356.31 574.95,363.07 580.75,369.90 586.56,376.80 592.36,383.74 598.16,390.72 603.96,397.72 609.76,404.75 615.56,411.80 621.37,418.86 627.17,425.94 632.97,433.02 638.77,440.12 644.57,447.23 650.38,454.34 656.18,461.46 661.98,468.58 667.78,475.71 673.58,482.84 679.39,489.98 685.19,497.12 690.99,504.26 690.99,176.45 685.19,180.46 679.39,184.47 673.58,188.48 667.78,192.48 661.98,196.47 656.18,200.46 650.38,204.45 644.57,208.43 638.77,212.40 632.97,216.37 627.17,220.32 621.37,224.26 615.56,228.19 609.76,232.11 603.96,236.00 598.16,239.87 592.36,243.72 586.56,247.53 580.75,251.29 574.95,254.99 569.15,258.62 563.35,262.14 557.55,265.51 551.74,268.67 545.94,271.52 540.14,273.90 534.34,275.55 528.54,276.14 522.73,275.30 516.93,272.88 511.13,269.06 505.33,264.21 499.53,258.65 493.72,252.64 487.92,246.32 482.12,239.80 476.32,233.14 470.52,226.38 464.71,219.53 458.91,212.63 453.11,205.69 447.31,198.71 441.51,191.70 435.70,184.67 429.90,177.63 424.10,170.56 418.30,163.48 412.50,156.40 406.69,149.30 400.89,142.19 395.09,135.08 389.29,127.96 383.49,120.84 377.68,113.71 371.88,106.57 366.08,99.44 360.28,92.30 354.48,85.15 348.67,78.00 342.87,70.86 337.07,63.70 331.27,56.55 325.47,49.40 319.67,42.24 313.86,35.08 308.06,27.92 302.26,20.76 296.46,13.60 290.66,6.43 284.85,-0.73 279.05,-7.90 273.25,-15.06 267.45,-22.23 261.65,-29.40 255.84,-36.57 250.04,-43.74 244.24,-50.91 238.44,-58.08 232.64,-65.25 226.83,-72.42 221.03,-79.60 215.23,-86.77 209.43,-93.94 203.63,-101.12 197.82,-108.29 192.02,-115.46 186.22,-122.64 180.42,-129.82 174.62,-136.99 168.81,-144.17 163.01,-151.34 157.21,-158.52 151.41,-165.70 145.61,-172.87 139.80,-180.05 134.00,-187.23 128.20,-194.41 122.40,-201.59 116.60,-208.76 110.79,-215.94 ' style='stroke-width: 1.07; stroke: none; fill: #CCCCCC;' />
+<polyline points='110.79,183.72 116.60,185.28 122.40,186.85 128.20,188.42 134.00,189.98 139.80,191.55 145.61,193.12 151.41,194.68 157.21,196.25 163.01,197.82 168.81,199.38 174.62,200.95 180.42,202.52 186.22,204.08 192.02,205.65 197.82,207.21 203.63,208.78 209.43,210.35 215.23,211.91 221.03,213.48 226.83,215.05 232.64,216.61 238.44,218.18 244.24,219.75 250.04,221.31 255.84,222.88 261.65,224.44 267.45,226.01 273.25,227.58 279.05,229.14 284.85,230.71 290.66,232.28 296.46,233.84 302.26,235.41 308.06,236.98 313.86,238.54 319.67,240.11 325.47,241.68 331.27,243.24 337.07,244.81 342.87,246.37 348.67,247.94 354.48,249.51 360.28,251.07 366.08,252.64 371.88,254.21 377.68,255.77 383.49,257.34 389.29,258.91 395.09,260.47 400.89,262.04 406.69,263.60 412.50,265.17 418.30,266.74 424.10,268.30 429.90,269.87 435.70,271.44 441.51,273.00 447.31,274.57 453.11,276.14 458.91,277.70 464.71,279.27 470.52,280.84 476.32,282.40 482.12,283.97 487.92,285.53 493.72,287.10 499.53,288.67 505.33,290.23 511.13,291.80 516.93,293.37 522.73,294.93 528.54,296.50 534.34,298.07 540.14,299.63 545.94,301.20 551.74,302.76 557.55,304.33 563.35,305.90 569.15,307.46 574.95,309.03 580.75,310.60 586.56,312.16 592.36,313.73 598.16,315.30 603.96,316.86 609.76,318.43 615.56,320.00 621.37,321.56 627.17,323.13 632.97,324.69 638.77,326.26 644.57,327.83 650.38,329.39 656.18,330.96 661.98,332.53 667.78,334.09 673.58,335.66 679.39,337.23 685.19,338.79 690.99,340.36 ' style='stroke-width: 2.67; stroke-linecap: butt;' />
+<polygon points='525.94,388.92 528.43,386.43 530.92,388.92 528.43,391.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,350.17 516.02,347.68 518.51,350.17 516.02,352.65 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.37,276.36 502.85,273.87 505.34,276.36 502.85,278.84 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='561.36,149.88 563.85,147.40 566.34,149.88 563.85,152.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.55,411.99 515.04,409.51 517.52,411.99 515.04,414.48 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='533.73,153.65 536.21,151.17 538.70,153.65 536.21,156.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.73,135.84 525.22,133.35 527.71,135.84 525.22,138.33 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.71,243.61 494.20,241.12 496.69,243.61 494.20,246.10 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.94,255.44 528.43,252.95 530.92,255.44 528.43,257.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='544.41,462.29 546.90,459.80 549.38,462.29 546.90,464.78 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.73,410.45 525.22,407.96 527.71,410.45 525.22,412.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='530.34,421.05 532.82,418.57 535.31,421.05 532.82,423.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='495.10,233.79 497.59,231.31 500.08,233.79 497.59,236.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.54,345.79 520.03,343.30 522.52,345.79 520.03,348.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.08,202.62 505.57,200.13 508.06,202.62 505.57,205.10 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.54,304.13 520.03,301.64 522.52,304.13 520.03,306.62 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.53,222.31 519.02,219.82 521.51,222.31 519.02,224.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.83,117.56 499.32,115.07 501.81,117.56 499.32,120.05 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,347.28 495.88,344.79 498.37,347.28 495.88,349.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='539.56,199.74 542.05,197.25 544.54,199.74 542.05,202.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='497.71,139.69 500.20,137.20 502.68,139.69 500.20,142.18 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='549.42,408.22 551.91,405.73 554.40,408.22 551.91,410.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,247.02 517.01,244.53 519.50,247.02 517.01,249.51 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.37,439.41 502.85,436.92 505.34,439.41 502.85,441.90 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='494.25,388.30 496.74,385.81 499.22,388.30 496.74,390.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='532.59,345.06 535.08,342.57 537.56,345.06 535.08,347.55 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='549.42,479.61 551.91,477.12 554.40,479.61 551.91,482.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.79,346.42 526.28,343.93 528.77,346.42 526.28,348.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,164.65 516.02,162.16 518.51,164.65 516.02,167.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='505.85,361.74 508.34,359.26 510.83,361.74 508.34,364.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='544.41,309.88 546.90,307.39 549.38,309.88 546.90,312.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,266.44 516.02,263.95 518.51,266.44 516.02,268.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.79,305.66 526.28,303.18 528.77,305.66 526.28,308.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='507.73,417.57 510.22,415.08 512.71,417.57 510.22,420.06 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='538.38,180.79 540.86,178.30 543.35,180.79 540.86,183.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.96,240.74 544.45,238.26 546.94,240.74 544.45,243.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='537.20,193.38 539.69,190.89 542.18,193.38 539.69,195.87 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='558.63,445.73 561.11,443.24 563.60,445.73 561.11,448.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.96,220.02 544.45,217.53 546.94,220.02 544.45,222.50 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,335.86 495.88,333.37 498.37,335.86 495.88,338.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,183.24 523.12,180.75 525.61,183.24 523.12,185.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='548.15,248.75 550.64,246.26 553.13,248.75 550.64,251.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.53,197.66 516.02,195.17 518.51,197.66 516.02,200.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.54,283.70 520.03,281.21 522.52,283.70 520.03,286.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.68,292.32 524.17,289.83 526.66,292.32 524.17,294.81 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.08,195.23 505.57,192.74 508.06,195.23 505.57,197.72 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='501.26,476.05 503.75,473.56 506.24,476.05 503.75,478.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='554.61,311.67 557.10,309.18 559.59,311.67 557.10,314.16 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='505.85,216.78 508.34,214.29 510.83,216.78 508.34,219.27 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,231.65 517.01,229.17 519.50,231.65 517.01,234.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.52,311.52 518.01,309.04 520.50,311.52 518.01,314.01 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.52,167.89 518.01,165.40 520.50,167.89 518.01,170.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='492.55,326.04 495.04,323.55 497.53,326.04 495.04,328.53 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='551.99,396.42 554.48,393.93 556.97,396.42 554.48,398.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='546.89,459.10 549.38,456.61 551.87,459.10 549.38,461.59 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='531.46,448.78 533.95,446.29 536.43,448.78 533.95,451.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='529.22,370.50 531.71,368.01 534.20,370.50 531.71,372.99 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,296.41 495.88,293.93 498.37,296.41 495.88,298.90 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='553.30,243.16 555.78,240.67 558.27,243.16 555.78,245.65 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='557.28,337.49 559.76,335.00 562.25,337.49 559.76,339.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.79,148.09 526.28,145.60 528.77,148.09 526.28,150.58 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='479.74,378.73 482.23,376.25 484.72,378.73 482.23,381.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='505.85,318.34 508.34,315.85 510.83,318.34 508.34,320.83 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,364.64 523.12,362.15 525.61,364.64 523.12,367.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='509.64,247.32 512.12,244.83 514.61,247.32 512.12,249.81 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='539.56,391.63 542.05,389.14 544.54,391.63 542.05,394.12 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.94,311.18 528.43,308.70 530.92,311.18 528.43,313.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='568.43,203.95 570.92,201.46 573.41,203.95 570.92,206.44 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='580.46,454.24 582.95,451.75 585.44,454.24 582.95,456.72 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.68,162.49 524.17,160.01 526.66,162.49 524.17,164.98 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='543.18,362.21 545.67,359.72 548.16,362.21 545.67,364.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,176.20 517.01,173.71 519.50,176.20 517.01,178.69 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,359.44 523.12,356.95 525.61,359.44 523.12,361.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,364.14 495.88,361.65 498.37,364.14 495.88,366.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='510.60,311.99 513.09,309.50 515.58,311.99 513.09,314.48 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='538.38,156.03 540.86,153.54 543.35,156.03 540.86,158.52 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='532.59,166.69 535.08,164.21 537.56,166.69 535.08,169.18 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='549.42,343.64 551.91,341.15 554.40,343.64 551.91,346.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='509.64,199.79 512.12,197.30 514.61,199.79 512.12,202.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.52,129.68 517.01,127.19 519.50,129.68 517.01,132.17 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.68,327.30 511.17,324.81 513.66,327.30 511.17,329.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.73,224.23 525.22,221.74 527.71,224.23 525.22,226.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='527.03,339.99 529.51,337.50 532.00,339.99 529.51,342.48 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.63,367.20 523.12,364.71 525.61,367.20 523.12,369.69 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='527.03,207.44 529.51,204.95 532.00,207.44 529.51,209.92 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='495.10,411.63 497.59,409.14 500.08,411.63 497.59,414.12 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='558.63,224.75 561.11,222.26 563.60,224.75 561.11,227.24 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.55,440.79 515.04,438.31 517.52,440.79 515.04,443.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='493.40,396.17 495.88,393.68 498.37,396.17 495.88,398.66 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='504.92,433.03 507.41,430.54 509.90,433.03 507.41,435.51 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='565.56,398.29 568.05,395.80 570.54,398.29 568.05,400.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='504.00,463.31 506.48,460.82 508.97,463.31 506.48,465.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.68,250.53 524.17,248.04 526.66,250.53 524.17,253.02 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='494.25,162.13 496.74,159.64 499.22,162.13 496.74,164.62 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.55,199.18 515.04,196.70 517.52,199.18 515.04,201.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='502.17,192.21 504.66,189.73 507.15,192.21 504.66,194.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='559.99,319.73 562.48,317.25 564.96,319.73 562.48,322.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='536.03,336.30 538.52,333.81 541.01,336.30 538.52,338.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='519.60,187.07 522.08,184.58 524.57,187.07 522.08,189.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.86,264.44 527.35,261.96 529.84,264.44 527.35,266.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<line x1='110.48' y1='507.09' x2='691.31' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='81.78' y1='485.30' x2='81.78' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='81.78' y='20.71' width='638.22' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='81.78,507.09 81.78,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='66.31' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='66.31' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<text x='66.31' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.20</text>
+<text x='66.31' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='66.31' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.30</text>
+<text x='66.31' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.35</text>
+<polyline points='73.28,484.99 81.78,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,396.55 81.78,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,308.12 81.78,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,219.68 81.78,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,131.25 81.78,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='73.28,42.82 81.78,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='81.78,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='110.79,515.60 110.79,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='226.83,515.60 226.83,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='342.87,515.60 342.87,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='458.91,515.60 458.91,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='574.95,515.60 574.95,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='690.99,515.60 690.99,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='110.79' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='226.83' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.02</text>
+<text x='342.87' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.04</text>
+<text x='458.91' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.06</text>
+<text x='574.95' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.08</text>
+<text x='690.99' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='400.89' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='133.81px' lengthAdjust='spacingAndGlyphs'>Standard Error</text>
+<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='86.66px' lengthAdjust='spacingAndGlyphs'>Fisher's z</text>
+<text x='400.89' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='230.58px' lengthAdjust='spacingAndGlyphs'>test2-estimated-pet-regression</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test2-mean-model-estimates.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test2-mean-model-estimates.svg
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpMTA1LjQxfDcyMC4wMHwyMC43MXw1MDcuMDk='>
+    <rect x='105.41' y='20.71' width='614.59' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTA1LjQxfDcyMC4wMHwyMC43MXw1MDcuMDk=)'>
+<rect x='105.41' y='20.71' width='614.59' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polyline points='559.60,479.46 559.60,379.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='559.60,429.71 302.49,429.71 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='302.49,479.46 302.49,379.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='692.06,368.92 692.06,269.43 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='692.06,319.17 194.87,319.17 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='194.87,368.92 194.87,269.43 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='420.21,258.37 420.21,158.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='420.21,208.63 389.37,208.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='389.37,258.37 389.37,158.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='414.17,147.83 414.17,48.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='414.17,98.09 386.82,98.09 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='386.82,147.83 386.82,48.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polygon points='435.54,431.67 439.44,431.67 439.44,427.76 435.54,427.76 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='468.44,321.13 472.35,321.13 472.35,317.22 468.44,317.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='402.87,210.58 406.78,210.58 406.78,206.68 402.87,206.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='398.57,100.04 402.48,100.04 402.48,96.13 398.57,96.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polyline points='133.34,484.99 133.34,42.82 ' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<line x1='133.03' y1='507.09' x2='656.28' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='105.41' y='20.71' width='614.59' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='105.41,507.09 105.41,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='89.93' y='435.56' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='56.71px' lengthAdjust='spacingAndGlyphs'>PEESE</text>
+<text x='89.93' y='325.02' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.07px' lengthAdjust='spacingAndGlyphs'>PET</text>
+<text x='89.93' y='214.48' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='50.07px' lengthAdjust='spacingAndGlyphs'>WAAP</text>
+<text x='89.93' y='103.94' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='36.84px' lengthAdjust='spacingAndGlyphs'>WLS</text>
+<polyline points='105.41,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='133.34,515.60 133.34,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='264.00,515.60 264.00,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='394.65,515.60 394.65,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='525.30,515.60 525.30,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='655.96,515.60 655.96,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='133.34' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='264.00' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='394.65' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='525.30' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='655.96' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='412.70' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='177.15px' lengthAdjust='spacingAndGlyphs'>Mean Estimates (ρ)</text>
+<text x='412.70' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='231.50px' lengthAdjust='spacingAndGlyphs'>test2-mean-model-estimates-ï-</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test3-estimated-peese-regression.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test3-estimated-peese-regression.svg
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpNzIuMzN8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
+    <rect x='72.33' y='20.71' width='647.67' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzIuMzN8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
+<rect x='72.33' y='20.71' width='647.67' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polygon points='101.77,556.84 107.66,556.79 113.54,556.64 119.43,556.38 125.32,556.02 131.21,555.56 137.10,554.99 142.98,554.32 148.87,553.55 154.76,552.68 160.65,551.71 166.54,550.63 172.42,549.45 178.31,548.16 184.20,546.78 190.09,545.29 195.98,543.70 201.86,542.00 207.75,540.20 213.64,538.30 219.53,536.30 225.42,534.20 231.30,531.99 237.19,529.68 243.08,527.27 248.97,524.76 254.85,522.14 260.74,519.42 266.63,516.60 272.52,513.68 278.41,510.65 284.29,507.52 290.18,504.30 296.07,500.96 301.96,497.53 307.85,494.00 313.73,490.36 319.62,486.62 325.51,482.78 331.40,478.84 337.29,474.80 343.17,470.66 349.06,466.41 354.95,462.07 360.84,457.63 366.73,453.08 372.61,448.44 378.50,443.70 384.39,438.86 390.28,433.92 396.16,428.89 402.05,423.76 407.94,418.53 413.83,413.21 419.72,407.80 425.60,402.29 431.49,396.70 437.38,391.02 443.27,385.26 449.16,379.43 455.04,373.52 460.93,367.55 466.82,361.53 472.71,355.48 478.60,349.41 484.48,343.37 490.37,337.40 496.26,331.59 502.15,326.07 508.04,321.05 513.92,316.83 519.81,313.82 525.70,312.35 531.59,312.44 537.47,313.82 543.36,316.14 549.25,319.10 555.14,322.49 561.03,326.19 566.91,330.13 572.80,334.24 578.69,338.51 584.58,342.90 590.47,347.40 596.35,352.00 602.24,356.69 608.13,361.46 614.02,366.31 619.91,371.24 625.79,376.23 631.68,381.30 637.57,386.44 643.46,391.64 649.35,396.91 655.23,402.24 661.12,407.64 667.01,413.10 672.90,418.62 678.78,424.21 684.67,429.85 690.56,435.56 690.56,39.31 684.67,49.53 678.78,59.64 672.90,69.64 667.01,79.54 661.12,89.33 655.23,99.01 649.35,108.58 643.46,118.04 637.57,127.39 631.68,136.63 625.79,145.75 619.91,154.76 614.02,163.65 608.13,172.42 602.24,181.07 596.35,189.59 590.47,197.97 584.58,206.21 578.69,214.29 572.80,222.21 566.91,229.93 561.03,237.42 555.14,244.64 549.25,251.49 543.36,257.87 537.47,263.56 531.59,268.28 525.70,271.66 519.81,273.42 513.92,273.61 508.04,272.54 502.15,270.62 496.26,268.16 490.37,265.36 484.48,262.37 478.60,259.25 472.71,256.06 466.82,252.84 460.93,249.60 455.04,246.38 449.16,243.17 443.27,239.98 437.38,236.83 431.49,233.71 425.60,230.63 419.72,227.60 413.83,224.61 407.94,221.67 402.05,218.78 396.16,215.94 390.28,213.14 384.39,210.40 378.50,207.72 372.61,205.08 366.73,202.50 360.84,199.98 354.95,197.50 349.06,195.09 343.17,192.72 337.29,190.42 331.40,188.17 325.51,185.97 319.62,183.83 313.73,181.75 307.85,179.72 301.96,177.75 296.07,175.83 290.18,173.97 284.29,172.17 278.41,170.43 272.52,168.74 266.63,167.11 260.74,165.53 254.85,164.01 248.97,162.55 243.08,161.15 237.19,159.80 231.30,158.51 225.42,157.28 219.53,156.11 213.64,154.99 207.75,153.93 201.86,152.92 195.98,151.98 190.09,151.09 184.20,150.26 178.31,149.48 172.42,148.76 166.54,148.10 160.65,147.50 154.76,146.96 148.87,146.47 142.98,146.04 137.10,145.66 131.21,145.35 125.32,145.09 119.43,144.89 113.54,144.75 107.66,144.66 101.77,144.63 ' style='stroke-width: 1.07; stroke: none; fill: #CCCCCC;' />
+<polyline points='101.77,350.74 107.66,350.72 113.54,350.69 119.43,350.63 125.32,350.55 131.21,350.45 137.10,350.33 142.98,350.18 148.87,350.01 154.76,349.82 160.65,349.60 166.54,349.37 172.42,349.10 178.31,348.82 184.20,348.52 190.09,348.19 195.98,347.84 201.86,347.46 207.75,347.07 213.64,346.65 219.53,346.20 225.42,345.74 231.30,345.25 237.19,344.74 243.08,344.21 248.97,343.65 254.85,343.08 260.74,342.48 266.63,341.85 272.52,341.21 278.41,340.54 284.29,339.85 290.18,339.13 296.07,338.40 301.96,337.64 307.85,336.86 313.73,336.05 319.62,335.23 325.51,334.38 331.40,333.50 337.29,332.61 343.17,331.69 349.06,330.75 354.95,329.79 360.84,328.80 366.73,327.79 372.61,326.76 378.50,325.71 384.39,324.63 390.28,323.53 396.16,322.41 402.05,321.27 407.94,320.10 413.83,318.91 419.72,317.70 425.60,316.46 431.49,315.21 437.38,313.93 443.27,312.62 449.16,311.30 455.04,309.95 460.93,308.58 466.82,307.18 472.71,305.77 478.60,304.33 484.48,302.87 490.37,301.38 496.26,299.88 502.15,298.35 508.04,296.79 513.92,295.22 519.81,293.62 525.70,292.00 531.59,290.36 537.47,288.69 543.36,287.01 549.25,285.29 555.14,283.56 561.03,281.81 566.91,280.03 572.80,278.23 578.69,276.40 584.58,274.55 590.47,272.68 596.35,270.79 602.24,268.88 608.13,266.94 614.02,264.98 619.91,263.00 625.79,260.99 631.68,258.96 637.57,256.91 643.46,254.84 649.35,252.74 655.23,250.63 661.12,248.48 667.01,246.32 672.90,244.13 678.78,241.92 684.67,239.69 690.56,237.44 ' style='stroke-width: 2.67; stroke-linecap: butt;' />
+<polygon points='522.36,387.84 524.85,385.35 527.34,387.84 524.85,390.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='510.72,348.55 513.21,346.06 515.70,348.55 513.21,351.04 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='499.19,273.30 501.68,270.81 504.17,273.30 501.68,275.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='564.61,142.71 567.10,140.22 569.59,142.71 567.10,145.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.60,411.16 511.08,408.67 513.57,411.16 511.08,413.65 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='536.55,146.63 539.04,144.14 541.53,146.63 539.04,149.12 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.06,128.05 528.55,125.57 531.04,128.05 528.55,130.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.31,239.70 493.80,237.22 496.28,239.70 493.80,242.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.46,251.85 527.95,249.37 530.44,251.85 527.95,254.34 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='539.54,461.86 542.03,459.37 544.52,461.86 542.03,464.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='518.78,409.60 521.27,407.11 523.76,409.60 521.27,412.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.18,420.31 528.67,417.82 531.16,420.31 528.67,422.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='495.00,229.60 497.49,227.12 499.97,229.60 497.49,232.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.83,344.11 517.32,341.62 519.81,344.11 517.32,346.60 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.95,197.44 506.44,194.95 508.93,197.44 506.44,199.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.77,301.69 518.26,299.20 520.75,301.69 518.26,304.18 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.94,217.77 519.43,215.28 521.92,217.77 519.43,220.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.39,108.93 502.88,106.44 505.37,108.93 502.88,111.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.61,345.62 493.10,343.13 495.59,345.62 493.10,348.11 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='540.86,194.46 543.34,191.98 545.83,194.46 543.34,196.95 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.52,132.07 503.00,129.58 505.49,132.07 503.00,134.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='545.39,407.35 547.88,404.86 550.37,407.35 547.88,409.84 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.21,243.21 516.70,240.72 519.19,243.21 516.70,245.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.02,438.82 498.51,436.33 501.00,438.82 498.51,441.31 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.70,387.21 493.19,384.72 495.68,387.21 493.19,389.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='529.88,343.36 532.37,340.87 534.86,343.36 532.37,345.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='544.28,479.28 546.77,476.80 549.26,479.28 546.77,481.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.07,344.74 523.55,342.26 526.04,344.74 523.55,347.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.73,158.07 518.22,155.59 520.71,158.07 518.22,160.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='502.80,360.30 505.29,357.81 507.78,360.30 505.29,362.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='542.52,307.56 545.01,305.07 547.50,307.56 545.01,310.04 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.69,263.14 515.18,260.65 517.66,263.14 515.18,265.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.99,303.25 524.48,300.76 526.97,303.25 524.48,305.74 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.70,416.79 506.19,414.31 508.67,416.79 506.19,419.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='540.30,174.84 542.79,172.35 545.27,174.84 542.79,177.33 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.98,236.75 544.47,234.27 546.96,236.75 544.47,239.24 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='538.69,187.88 541.17,185.39 543.66,187.88 541.17,190.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='553.89,445.19 556.38,442.71 558.87,445.19 556.38,447.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='542.62,215.41 545.11,212.92 547.60,215.41 545.11,217.89 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.84,334.01 493.33,331.52 495.82,334.01 493.33,336.50 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.30,177.37 524.79,174.89 527.28,177.37 524.79,179.86 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='547.95,244.98 550.44,242.49 552.92,244.98 550.44,247.47 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.66,192.32 517.15,189.83 519.64,192.32 517.15,194.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.27,280.81 518.76,278.32 521.25,280.81 518.76,283.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.20,289.63 522.69,287.14 525.18,289.63 522.69,292.11 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='504.17,189.80 506.66,187.31 509.15,189.80 506.66,192.29 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.44,475.71 498.93,473.22 501.42,475.71 498.93,478.20 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='552.67,309.37 555.15,306.89 557.64,309.37 555.15,311.86 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='506.33,212.07 508.82,209.58 511.30,212.07 508.82,214.55 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.65,227.40 517.13,224.91 519.62,227.40 517.13,229.89 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.57,309.23 516.06,306.74 518.54,309.23 516.06,311.72 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.64,161.44 520.13,158.96 522.62,161.44 520.13,163.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.19,324.02 492.68,321.53 495.17,324.02 492.68,326.50 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='548.17,395.42 550.66,392.93 553.14,395.42 550.66,397.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='542.05,458.66 544.54,456.17 547.03,458.66 544.54,461.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.87,448.26 529.35,445.77 531.84,448.26 529.35,450.75 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.99,369.18 528.48,366.69 530.97,369.18 528.48,371.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.70,293.81 494.19,291.32 496.68,293.81 494.19,296.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='553.28,239.24 555.76,236.75 558.25,239.24 555.76,241.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='554.69,335.67 557.18,333.18 559.66,335.67 557.18,338.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.70,140.84 529.19,138.35 531.67,140.84 529.19,143.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='476.33,377.52 478.82,375.04 481.31,377.52 478.82,380.01 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.71,316.18 506.20,313.69 508.69,316.18 506.20,318.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.53,363.24 520.02,360.75 522.51,363.24 520.02,365.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='509.28,243.52 511.77,241.03 514.26,243.52 511.77,246.01 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='535.89,390.58 538.38,388.09 540.87,390.58 538.38,393.07 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.01,308.88 526.50,306.39 528.99,308.88 526.50,311.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='569.74,198.82 572.23,196.33 574.72,198.82 572.23,201.31 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='575.38,453.76 577.87,451.27 580.36,453.76 577.87,456.25 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.05,155.83 526.54,153.35 529.03,155.83 526.54,158.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='540.09,360.77 542.57,358.29 545.06,360.77 542.57,363.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.35,170.07 518.84,167.58 521.33,170.07 518.84,172.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.64,357.96 520.12,355.47 522.61,357.96 520.12,360.45 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.28,362.73 492.77,360.24 495.26,362.73 492.77,365.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.62,309.70 511.11,307.22 513.60,309.70 511.11,312.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.17,149.11 543.66,146.62 546.15,149.11 543.66,151.59 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='534.94,160.20 537.43,157.71 539.92,160.20 537.43,162.69 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='546.71,341.92 549.20,339.44 551.69,341.92 549.20,344.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='510.66,194.51 513.15,192.02 515.64,194.51 513.15,197.00 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.96,121.62 520.44,119.13 522.93,121.62 520.44,124.10 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='506.35,325.30 508.84,322.81 511.33,325.30 508.84,327.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.13,219.75 525.62,217.26 528.11,219.75 525.62,222.24 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.44,338.21 526.93,335.72 529.41,338.21 526.93,340.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.48,365.84 519.97,363.35 522.46,365.84 519.97,368.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='527.98,202.42 530.46,199.93 532.95,202.42 530.46,204.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.18,410.79 493.66,408.31 496.15,410.79 493.66,413.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='559.20,220.29 561.69,217.80 564.18,220.29 561.69,222.78 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.15,440.22 510.64,437.73 513.13,440.22 510.64,442.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='489.72,395.17 492.21,392.68 494.70,395.17 492.21,397.66 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.66,432.39 503.15,429.90 505.63,432.39 503.15,434.87 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='561.61,397.31 564.10,394.82 566.59,397.31 564.10,399.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='499.32,462.89 501.81,460.40 504.30,462.89 501.81,465.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.31,246.81 523.80,244.32 526.29,246.81 523.80,249.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.26,155.46 498.75,152.97 501.24,155.46 498.75,157.95 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.62,193.89 516.11,191.40 518.60,193.89 516.11,196.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.34,186.68 505.83,184.19 508.32,186.68 505.83,189.16 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='557.83,317.60 560.31,315.11 562.80,317.60 560.31,320.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='533.52,334.46 536.01,331.97 538.50,334.46 536.01,336.94 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.13,181.34 523.62,178.86 526.10,181.34 523.62,183.83 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.13,261.09 526.62,258.60 529.10,261.09 526.62,263.58 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<line x1='101.45' y1='507.09' x2='690.88' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='72.33' y1='485.30' x2='72.33' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='72.33' y='20.71' width='647.67' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='72.33,507.09 72.33,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='56.85' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='56.85' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='56.85' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='56.85' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='56.85' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='56.85' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<polyline points='63.83,484.99 72.33,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,396.55 72.33,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,308.12 72.33,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,219.68 72.33,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,131.25 72.33,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,42.82 72.33,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='72.33,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='101.77,515.60 101.77,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='248.97,515.60 248.97,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='396.16,515.60 396.16,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='543.36,515.60 543.36,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='690.56,515.60 690.56,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='101.77' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='248.97' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.05</text>
+<text x='396.16' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='543.36' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<text x='690.56' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.20</text>
+<text x='396.16' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='133.81px' lengthAdjust='spacingAndGlyphs'>Standard Error</text>
+<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='91.24px' lengthAdjust='spacingAndGlyphs'>Cohen's d</text>
+<text x='396.16' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='253.28px' lengthAdjust='spacingAndGlyphs'>test3-estimated-peese-regression</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test3-estimated-pet-regression.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test3-estimated-pet-regression.svg
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpNzIuMzN8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
+    <rect x='72.33' y='20.71' width='647.67' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzIuMzN8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
+<rect x='72.33' y='20.71' width='647.67' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polygon points='101.77,836.72 107.66,829.11 113.54,821.50 119.43,813.89 125.32,806.28 131.21,798.67 137.10,791.06 142.98,783.45 148.87,775.84 154.76,768.24 160.65,760.63 166.54,753.02 172.42,745.42 178.31,737.81 184.20,730.20 190.09,722.60 195.98,714.99 201.86,707.39 207.75,699.78 213.64,692.18 219.53,684.57 225.42,676.97 231.30,669.37 237.19,661.77 243.08,654.17 248.97,646.56 254.85,638.96 260.74,631.37 266.63,623.77 272.52,616.17 278.41,608.57 284.29,600.98 290.18,593.38 296.07,585.79 301.96,578.20 307.85,570.60 313.73,563.01 319.62,555.43 325.51,547.84 331.40,540.26 337.29,532.67 343.17,525.09 349.06,517.52 354.95,509.94 360.84,502.37 366.73,494.80 372.61,487.23 378.50,479.67 384.39,472.12 390.28,464.57 396.16,457.02 402.05,449.48 407.94,441.95 413.83,434.43 419.72,426.92 425.60,419.42 431.49,411.94 437.38,404.48 443.27,397.03 449.16,389.62 455.04,382.23 460.93,374.89 466.82,367.61 472.71,360.39 478.60,353.27 484.48,346.28 490.37,339.48 496.26,332.95 502.15,326.84 508.04,321.37 513.92,316.86 519.81,313.70 525.70,312.16 531.59,312.19 537.47,313.43 543.36,315.52 549.25,318.15 555.14,321.14 561.03,324.37 566.91,327.77 572.80,331.29 578.69,334.89 584.58,338.56 590.47,342.27 596.35,346.03 602.24,349.81 608.13,353.62 614.02,357.45 619.91,361.30 625.79,365.16 631.68,369.03 637.57,372.92 643.46,376.81 649.35,380.71 655.23,384.62 661.12,388.53 667.01,392.45 672.90,396.37 678.78,400.29 684.67,404.22 690.56,408.16 690.56,73.37 684.67,80.95 678.78,88.52 672.90,96.08 667.01,103.65 661.12,111.20 655.23,118.76 649.35,126.30 643.46,133.84 637.57,141.38 631.68,148.90 625.79,156.42 619.91,163.92 614.02,171.41 608.13,178.88 602.24,186.33 596.35,193.75 590.47,201.15 584.58,208.51 578.69,215.81 572.80,223.06 566.91,230.21 561.03,237.25 555.14,244.12 549.25,250.76 543.36,257.03 537.47,262.76 531.59,267.64 525.70,271.31 519.81,273.41 513.92,273.89 508.04,273.02 502.15,271.19 496.26,268.72 490.37,265.83 484.48,262.67 478.60,259.33 472.71,255.85 466.82,252.27 460.93,248.62 455.04,244.92 449.16,241.18 443.27,237.41 437.38,233.60 431.49,229.78 425.60,225.94 419.72,222.08 413.83,218.21 407.94,214.33 402.05,210.44 396.16,206.54 390.28,202.64 384.39,198.73 378.50,194.81 372.61,190.89 366.73,186.97 360.84,183.04 354.95,179.11 349.06,175.18 343.17,171.24 337.29,167.30 331.40,163.36 325.51,159.41 319.62,155.47 313.73,151.52 307.85,147.57 301.96,143.62 296.07,139.67 290.18,135.72 284.29,131.76 278.41,127.81 272.52,123.85 266.63,119.89 260.74,115.94 254.85,111.98 248.97,108.02 243.08,104.06 237.19,100.10 231.30,96.14 225.42,92.17 219.53,88.21 213.64,84.25 207.75,80.29 201.86,76.32 195.98,72.36 190.09,68.39 184.20,64.43 178.31,60.46 172.42,56.50 166.54,52.53 160.65,48.56 154.76,44.60 148.87,40.63 142.98,36.66 137.10,32.70 131.21,28.73 125.32,24.76 119.43,20.79 113.54,16.82 107.66,12.85 101.77,8.89 ' style='stroke-width: 1.07; stroke: none; fill: #CCCCCC;' />
+<polyline points='101.77,422.80 107.66,420.98 113.54,419.16 119.43,417.34 125.32,415.52 131.21,413.70 137.10,411.88 142.98,410.06 148.87,408.24 154.76,406.42 160.65,404.60 166.54,402.78 172.42,400.96 178.31,399.14 184.20,397.32 190.09,395.49 195.98,393.67 201.86,391.85 207.75,390.03 213.64,388.21 219.53,386.39 225.42,384.57 231.30,382.75 237.19,380.93 243.08,379.11 248.97,377.29 254.85,375.47 260.74,373.65 266.63,371.83 272.52,370.01 278.41,368.19 284.29,366.37 290.18,364.55 296.07,362.73 301.96,360.91 307.85,359.09 313.73,357.27 319.62,355.45 325.51,353.63 331.40,351.81 337.29,349.99 343.17,348.17 349.06,346.35 354.95,344.52 360.84,342.70 366.73,340.88 372.61,339.06 378.50,337.24 384.39,335.42 390.28,333.60 396.16,331.78 402.05,329.96 407.94,328.14 413.83,326.32 419.72,324.50 425.60,322.68 431.49,320.86 437.38,319.04 443.27,317.22 449.16,315.40 455.04,313.58 460.93,311.76 466.82,309.94 472.71,308.12 478.60,306.30 484.48,304.48 490.37,302.66 496.26,300.84 502.15,299.02 508.04,297.20 513.92,295.38 519.81,293.55 525.70,291.73 531.59,289.91 537.47,288.09 543.36,286.27 549.25,284.45 555.14,282.63 561.03,280.81 566.91,278.99 572.80,277.17 578.69,275.35 584.58,273.53 590.47,271.71 596.35,269.89 602.24,268.07 608.13,266.25 614.02,264.43 619.91,262.61 625.79,260.79 631.68,258.97 637.57,257.15 643.46,255.33 649.35,253.51 655.23,251.69 661.12,249.87 667.01,248.05 672.90,246.23 678.78,244.41 684.67,242.58 690.56,240.76 ' style='stroke-width: 2.67; stroke-linecap: butt;' />
+<polygon points='522.36,387.84 524.85,385.35 527.34,387.84 524.85,390.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='510.72,348.55 513.21,346.06 515.70,348.55 513.21,351.04 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='499.19,273.30 501.68,270.81 504.17,273.30 501.68,275.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='564.61,142.71 567.10,140.22 569.59,142.71 567.10,145.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.60,411.16 511.08,408.67 513.57,411.16 511.08,413.65 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='536.55,146.63 539.04,144.14 541.53,146.63 539.04,149.12 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.06,128.05 528.55,125.57 531.04,128.05 528.55,130.54 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.31,239.70 493.80,237.22 496.28,239.70 493.80,242.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.46,251.85 527.95,249.37 530.44,251.85 527.95,254.34 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='539.54,461.86 542.03,459.37 544.52,461.86 542.03,464.35 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='518.78,409.60 521.27,407.11 523.76,409.60 521.27,412.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.18,420.31 528.67,417.82 531.16,420.31 528.67,422.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='495.00,229.60 497.49,227.12 499.97,229.60 497.49,232.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.83,344.11 517.32,341.62 519.81,344.11 517.32,346.60 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.95,197.44 506.44,194.95 508.93,197.44 506.44,199.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.77,301.69 518.26,299.20 520.75,301.69 518.26,304.18 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.94,217.77 519.43,215.28 521.92,217.77 519.43,220.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.39,108.93 502.88,106.44 505.37,108.93 502.88,111.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.61,345.62 493.10,343.13 495.59,345.62 493.10,348.11 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='540.86,194.46 543.34,191.98 545.83,194.46 543.34,196.95 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.52,132.07 503.00,129.58 505.49,132.07 503.00,134.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='545.39,407.35 547.88,404.86 550.37,407.35 547.88,409.84 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.21,243.21 516.70,240.72 519.19,243.21 516.70,245.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.02,438.82 498.51,436.33 501.00,438.82 498.51,441.31 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.70,387.21 493.19,384.72 495.68,387.21 493.19,389.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='529.88,343.36 532.37,340.87 534.86,343.36 532.37,345.85 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='544.28,479.28 546.77,476.80 549.26,479.28 546.77,481.77 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.07,344.74 523.55,342.26 526.04,344.74 523.55,347.23 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='515.73,158.07 518.22,155.59 520.71,158.07 518.22,160.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='502.80,360.30 505.29,357.81 507.78,360.30 505.29,362.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='542.52,307.56 545.01,305.07 547.50,307.56 545.01,310.04 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='512.69,263.14 515.18,260.65 517.66,263.14 515.18,265.63 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.99,303.25 524.48,300.76 526.97,303.25 524.48,305.74 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.70,416.79 506.19,414.31 508.67,416.79 506.19,419.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='540.30,174.84 542.79,172.35 545.27,174.84 542.79,177.33 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.98,236.75 544.47,234.27 546.96,236.75 544.47,239.24 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='538.69,187.88 541.17,185.39 543.66,187.88 541.17,190.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='553.89,445.19 556.38,442.71 558.87,445.19 556.38,447.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='542.62,215.41 545.11,212.92 547.60,215.41 545.11,217.89 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.84,334.01 493.33,331.52 495.82,334.01 493.33,336.50 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='522.30,177.37 524.79,174.89 527.28,177.37 524.79,179.86 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='547.95,244.98 550.44,242.49 552.92,244.98 550.44,247.47 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.66,192.32 517.15,189.83 519.64,192.32 517.15,194.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.27,280.81 518.76,278.32 521.25,280.81 518.76,283.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='520.20,289.63 522.69,287.14 525.18,289.63 522.69,292.11 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='504.17,189.80 506.66,187.31 509.15,189.80 506.66,192.29 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.44,475.71 498.93,473.22 501.42,475.71 498.93,478.20 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='552.67,309.37 555.15,306.89 557.64,309.37 555.15,311.86 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='506.33,212.07 508.82,209.58 511.30,212.07 508.82,214.55 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='514.65,227.40 517.13,224.91 519.62,227.40 517.13,229.89 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.57,309.23 516.06,306.74 518.54,309.23 516.06,311.72 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.64,161.44 520.13,158.96 522.62,161.44 520.13,163.93 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.19,324.02 492.68,321.53 495.17,324.02 492.68,326.50 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='548.17,395.42 550.66,392.93 553.14,395.42 550.66,397.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='542.05,458.66 544.54,456.17 547.03,458.66 544.54,461.14 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.87,448.26 529.35,445.77 531.84,448.26 529.35,450.75 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='525.99,369.18 528.48,366.69 530.97,369.18 528.48,371.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.70,293.81 494.19,291.32 496.68,293.81 494.19,296.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='553.28,239.24 555.76,236.75 558.25,239.24 555.76,241.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='554.69,335.67 557.18,333.18 559.66,335.67 557.18,338.15 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='526.70,140.84 529.19,138.35 531.67,140.84 529.19,143.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='476.33,377.52 478.82,375.04 481.31,377.52 478.82,380.01 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.71,316.18 506.20,313.69 508.69,316.18 506.20,318.67 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.53,363.24 520.02,360.75 522.51,363.24 520.02,365.73 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='509.28,243.52 511.77,241.03 514.26,243.52 511.77,246.01 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='535.89,390.58 538.38,388.09 540.87,390.58 538.38,393.07 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.01,308.88 526.50,306.39 528.99,308.88 526.50,311.37 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='569.74,198.82 572.23,196.33 574.72,198.82 572.23,201.31 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='575.38,453.76 577.87,451.27 580.36,453.76 577.87,456.25 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.05,155.83 526.54,153.35 529.03,155.83 526.54,158.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='540.09,360.77 542.57,358.29 545.06,360.77 542.57,363.26 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='516.35,170.07 518.84,167.58 521.33,170.07 518.84,172.56 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.64,357.96 520.12,355.47 522.61,357.96 520.12,360.45 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='490.28,362.73 492.77,360.24 495.26,362.73 492.77,365.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.62,309.70 511.11,307.22 513.60,309.70 511.11,312.19 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='541.17,149.11 543.66,146.62 546.15,149.11 543.66,151.59 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='534.94,160.20 537.43,157.71 539.92,160.20 537.43,162.69 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='546.71,341.92 549.20,339.44 551.69,341.92 549.20,344.41 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='510.66,194.51 513.15,192.02 515.64,194.51 513.15,197.00 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.96,121.62 520.44,119.13 522.93,121.62 520.44,124.10 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='506.35,325.30 508.84,322.81 511.33,325.30 508.84,327.79 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='523.13,219.75 525.62,217.26 528.11,219.75 525.62,222.24 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.44,338.21 526.93,335.72 529.41,338.21 526.93,340.70 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='517.48,365.84 519.97,363.35 522.46,365.84 519.97,368.32 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='527.98,202.42 530.46,199.93 532.95,202.42 530.46,204.91 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='491.18,410.79 493.66,408.31 496.15,410.79 493.66,413.28 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='559.20,220.29 561.69,217.80 564.18,220.29 561.69,222.78 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='508.15,440.22 510.64,437.73 513.13,440.22 510.64,442.71 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='489.72,395.17 492.21,392.68 494.70,395.17 492.21,397.66 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='500.66,432.39 503.15,429.90 505.63,432.39 503.15,434.87 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='561.61,397.31 564.10,394.82 566.59,397.31 564.10,399.80 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='499.32,462.89 501.81,460.40 504.30,462.89 501.81,465.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.31,246.81 523.80,244.32 526.29,246.81 523.80,249.30 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='496.26,155.46 498.75,152.97 501.24,155.46 498.75,157.95 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='513.62,193.89 516.11,191.40 518.60,193.89 516.11,196.38 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='503.34,186.68 505.83,184.19 508.32,186.68 505.83,189.16 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='557.83,317.60 560.31,315.11 562.80,317.60 560.31,320.09 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='533.52,334.46 536.01,331.97 538.50,334.46 536.01,336.94 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='521.13,181.34 523.62,178.86 526.10,181.34 523.62,183.83 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='524.13,261.09 526.62,258.60 529.10,261.09 526.62,263.58 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<line x1='101.45' y1='507.09' x2='690.88' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='72.33' y1='485.30' x2='72.33' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='72.33' y='20.71' width='647.67' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='72.33,507.09 72.33,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='56.85' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='56.85' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='56.85' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='56.85' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='56.85' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='56.85' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<polyline points='63.83,484.99 72.33,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,396.55 72.33,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,308.12 72.33,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,219.68 72.33,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,131.25 72.33,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='63.83,42.82 72.33,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='72.33,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='101.77,515.60 101.77,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='248.97,515.60 248.97,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='396.16,515.60 396.16,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='543.36,515.60 543.36,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='690.56,515.60 690.56,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='101.77' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='248.97' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.05</text>
+<text x='396.16' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='543.36' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<text x='690.56' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.20</text>
+<text x='396.16' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='133.81px' lengthAdjust='spacingAndGlyphs'>Standard Error</text>
+<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='91.24px' lengthAdjust='spacingAndGlyphs'>Cohen's d</text>
+<text x='396.16' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='230.58px' lengthAdjust='spacingAndGlyphs'>test3-estimated-pet-regression</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/waapwlspetpeese/test3-mean-model-estimates.svg
+++ b/tests/testthat/_snaps/waapwlspetpeese/test3-mean-model-estimates.svg
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpMTA1LjQxfDcyMC4wMHwyMC43MXw1MDcuMDk='>
+    <rect x='105.41' y='20.71' width='614.59' height='486.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTA1LjQxfDcyMC4wMHwyMC43MXw1MDcuMDk=)'>
+<rect x='105.41' y='20.71' width='614.59' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polyline points='524.60,479.46 524.60,379.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='524.60,429.71 297.46,429.71 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='297.46,479.46 297.46,379.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='590.05,368.92 590.05,269.43 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='590.05,319.17 133.34,319.17 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='133.34,368.92 133.34,269.43 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='692.06,258.37 692.06,158.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='692.06,208.63 642.35,208.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='642.35,258.37 642.35,158.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='684.94,147.83 684.94,48.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='684.94,98.09 640.90,98.09 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='640.90,147.83 640.90,48.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polygon points='413.18,431.67 417.09,431.67 417.09,427.76 413.18,427.76 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='372.22,321.13 376.13,321.13 376.13,317.22 372.22,317.22 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='665.35,210.58 669.26,210.58 669.26,206.68 665.35,206.68 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='661.04,100.04 664.95,100.04 664.95,96.13 661.04,96.13 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polyline points='233.67,484.99 233.67,42.82 ' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<line x1='128.22' y1='507.09' x2='654.53' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='105.41' y='20.71' width='614.59' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='105.41,507.09 105.41,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='89.93' y='435.56' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='56.71px' lengthAdjust='spacingAndGlyphs'>PEESE</text>
+<text x='89.93' y='325.02' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='33.07px' lengthAdjust='spacingAndGlyphs'>PET</text>
+<text x='89.93' y='214.48' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='50.07px' lengthAdjust='spacingAndGlyphs'>WAAP</text>
+<text x='89.93' y='103.94' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='36.84px' lengthAdjust='spacingAndGlyphs'>WLS</text>
+<polyline points='105.41,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='128.54,515.60 128.54,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='233.67,515.60 233.67,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='338.81,515.60 338.81,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='443.94,515.60 443.94,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='549.08,515.60 549.08,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='654.21,515.60 654.21,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='128.54' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='38.75px' lengthAdjust='spacingAndGlyphs'>-0.05</text>
+<text x='233.67' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='338.81' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.05</text>
+<text x='443.94' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='549.08' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<text x='654.21' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.09px' lengthAdjust='spacingAndGlyphs'>0.20</text>
+<text x='412.70' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='177.15px' lengthAdjust='spacingAndGlyphs'>Mean Estimates (ρ)</text>
+<text x='412.70' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='231.50px' lengthAdjust='spacingAndGlyphs'>test3-mean-model-estimates-ï-</text>
+</g>
+</svg>

--- a/tests/testthat/test-selectionmodels.R
+++ b/tests/testthat/test-selectionmodels.R
@@ -15,8 +15,8 @@ context("Meta Analysis - Selection Models")
   options$plotModels <- TRUE
   set.seed(1)
   results <- jaspTools::runAnalysis("SelectionModels", "debug.csv", options)
-  
-  
+
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_meanFE"]][["data"]]
     expect_equal_tables(table,
@@ -25,7 +25,7 @@ context("Meta Analysis - Selection Models")
                              -0.285826305450531, 0.173350398233601, 0.086053876525732, -1.36151689453531,
                              "Adjusted", 0.0514986919904518))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_weightsFE"]][["data"]]
     expect_equal_tables(table,
@@ -34,13 +34,13 @@ context("Meta Analysis - Selection Models")
                              0.975, 0.608603517567196, 0, 0.975, 0.171765955252482, 0.445357204743356,
                              1.3665514133041, 1.4814875991196, 1))
   })
-  
+
   test_that("Weight Function (Fixed Effects) plot matches", {
     plotName <- results[["results"]][["FE_weights"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     expect_equal_plots(testPlot, "weight-function-fixed-effects-1")
   })
-  
+
   test_that("Heterogeneity Estimates (tau) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_heterogeneityRE"]][["data"]]
     expect_equal_tables(table,
@@ -49,7 +49,7 @@ context("Meta Analysis - Selection Models")
                              0.00714643352932713, 2.68994248199423, "Adjusted", 1.24041721935203
                         ))
   })
-  
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_meanRE"]][["data"]]
     expect_equal_tables(table,
@@ -58,7 +58,7 @@ context("Meta Analysis - Selection Models")
                              -0.833591009895464, 0.178773096114283, 0.252258868606951, -1.34454227325299,
                              "Adjusted", 0.155245584605427))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_weightsRE"]][["data"]]
     expect_equal_tables(table,
@@ -67,13 +67,13 @@ context("Meta Analysis - Selection Models")
                              0.439673866838272, 0, 0.975, 0.257423397168529, 0.388232271154997,
                              1.13250211150721, 1.20059513593825, 1))
   })
-  
+
   test_that("Weight Function (Random Effects) plot matches", {
     plotName <- results[["results"]][["RE_weights"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     expect_equal_plots(testPlot, "weight-function-random-effects-1")
   })
-  
+
   test_that("Test of Publication Bias table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
     expect_equal_tables(table,
@@ -81,19 +81,19 @@ context("Meta Analysis - Selection Models")
                              2, 0.231243622868297, 2.92856695951119, "Assuming heterogeneity"
                         ))
   })
-  
+
   test_that("Test of Heterogeneity table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_heterogeneityTest"]][["data"]]
     expect_equal_tables(table,
                         list(99, 2.70555845478692e-05, 167.546611260491))
   })
-  
+
   test_that("p-value Frequency table results match", {
     table <- results[["results"]][["pFrequency"]][["data"]]
     expect_equal_tables(table,
                         list(5, 0, 0.025, 90, 0.025, 0.975, 5, 0.975, 1))
   })
-  
+
   test_that("Mean Model Estimates (mu) plot matches", {
     plotName <- results[["results"]][["plotEstimates"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
@@ -114,14 +114,14 @@ context("Meta Analysis - Selection Models")
   options$weightFunctionRescale <- TRUE
   set.seed(1)
   results <- jaspTools::runAnalysis("SelectionModels", "debug.csv", options)
-  
-  
+
+
   test_that("[x-scaled] Weight Function (Fixed Effects) plot matches", {
     plotName <- results[["results"]][["FE_weights"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     expect_equal_plots(testPlot, "weight-function-fixed-effects-2")
   })
-  
+
   test_that("[x-scaled] Weight Function (Random Effects) plot matches", {
     plotName <- results[["results"]][["RE_weights"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
@@ -142,8 +142,8 @@ context("Meta Analysis - Selection Models")
   options$selectionTwosided <- FALSE
   set.seed(1)
   results <- jaspTools::runAnalysis("SelectionModels", "debug.csv", options)
-  
-  
+
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_meanFE"]][["data"]]
     expect_equal_tables(table,
@@ -152,7 +152,7 @@ context("Meta Analysis - Selection Models")
                              -0.289513693849079, 0.216602360468526, 0.0905982467042613, -1.23561324107818,
                              "Adjusted", 0.0656249073565744))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_weightsFE"]][["data"]]
     expect_equal_tables(table,
@@ -160,7 +160,7 @@ context("Meta Analysis - Selection Models")
                              0.0314798599518836, 0.48304687864256, 2.15095362881009, 1.98576592148551,
                              1))
   })
-  
+
   test_that("Heterogeneity Estimates (Ď„) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_heterogeneityRE"]][["data"]]
     expect_equal_tables(table,
@@ -169,7 +169,7 @@ context("Meta Analysis - Selection Models")
                              0.00271468346363547, 2.99832462391542, "Adjusted", 1.26555606730294
                         ))
   })
-  
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_meanRE"]][["data"]]
     expect_equal_tables(table,
@@ -178,14 +178,14 @@ context("Meta Analysis - Selection Models")
                              -1.06429019583397, 0.0303021145800322, 0.257942040203908, -2.16611873928669,
                              "Adjusted", -0.0531759780370833))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_weightsRE"]][["data"]]
     expect_equal_tables(table,
                         list(1, 1, 0, 0, 1, 0.05, 4.05572161073559, 0, 0.05, 0.0710518148153868,
                              2.24675526054569, 1.80514615096553, 8.45928100348104, 1))
   })
-  
+
   test_that("Test of Publication Bias table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
     expect_equal_tables(table,
@@ -193,7 +193,7 @@ context("Meta Analysis - Selection Models")
                              1, 0.00620168963938165, 7.49074491600277, "Assuming heterogeneity"
                         ))
   })
-  
+
   test_that("Test of Heterogeneity table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_heterogeneityTest"]][["data"]]
     expect_equal_tables(table,
@@ -219,8 +219,8 @@ context("Meta Analysis - Selection Models")
   options$selectionTwosided <- FALSE
   set.seed(1)
   results <- jaspTools::runAnalysis("SelectionModels", "debug.csv", options)
-  
-  
+
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_meanFE"]][["data"]]
     expect_equal_tables(table,
@@ -229,7 +229,7 @@ context("Meta Analysis - Selection Models")
                              -0.376005843961891, 0.174683758966281, 0.113347951506904, -1.35730676418616,
                              "Adjusted", 0.068309961387959))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_weightsFE"]][["data"]]
     expect_equal_tables(table,
@@ -240,13 +240,13 @@ context("Meta Analysis - Selection Models")
                              39.2483429180539, 0, 0.999, 0.227637391407715, 32.5316281308455,
                              1.20646721892286, 103.009162412961, 1))
   })
-  
+
   test_that("Weight Function (Fixed Effects) plot matches", {
     plotName <- results[["results"]][["FE_weights"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     expect_equal_plots(testPlot, "weight-function-fixed-effects-3")
   })
-  
+
   test_that("Heterogeneity Estimates (tau) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_heterogeneityRE"]][["data"]]
     expect_equal_tables(table,
@@ -255,7 +255,7 @@ context("Meta Analysis - Selection Models")
                              0.00997086944826132, 2.5768379111574, "Adjusted", 1.42605031114831
                         ))
   })
-  
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_meanRE"]][["data"]]
     expect_equal_tables(table,
@@ -264,7 +264,7 @@ context("Meta Analysis - Selection Models")
                              -0.819418767124643, 0.843390247253674, 0.464943469954447, 0.197558831920262,
                              "Adjusted", 1.00312614479095))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_weightsRE"]][["data"]]
     expect_equal_tables(table,
@@ -275,13 +275,13 @@ context("Meta Analysis - Selection Models")
                              0, 0.999, 0.464906129098306, 0.860905965056294, 0.73079213366684,
                              2.31648799267603, 1))
   })
-  
+
   test_that("Weight Function (Random Effects) plot matches", {
     plotName <- results[["results"]][["RE_weights"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     expect_equal_plots(testPlot, "weight-function-random-effects-3")
   })
-  
+
   test_that("Test of Publication Bias table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
     expect_equal_tables(table,
@@ -289,13 +289,13 @@ context("Meta Analysis - Selection Models")
                              3, 1.24070625524803e-05, 25.4541785368763, "Assuming heterogeneity"
                         ))
   })
-  
+
   test_that("Test of Heterogeneity table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_heterogeneityTest"]][["data"]]
     expect_equal_tables(table,
                         list(99, 2.70555845478692e-05, 167.546611260491))
   })
-  
+
   test_that("p-value Frequency table results match", {
     table <- results[["results"]][["pFrequency"]][["data"]]
     expect_equal_tables(table,
@@ -320,8 +320,8 @@ context("Meta Analysis - Selection Models")
   options$selectionTwosided <- FALSE
   set.seed(1)
   results <- jaspTools::runAnalysis("SelectionModels", "debug.csv", options)
-  
-  
+
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_meanFE"]][["data"]]
     expect_equal_tables(table,
@@ -330,7 +330,7 @@ context("Meta Analysis - Selection Models")
                              -0.355555366961861, 0.302699620457382, 0.118889970600671, -1.03066142452918,
                              "Adjusted", 0.110484754038821))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_weightsFE"]][["data"]]
     expect_equal_tables(table,
@@ -340,7 +340,7 @@ context("Meta Analysis - Selection Models")
                              0.336326563988725, 2.18504987145378, 1.39407826787206, 1))
   })
 
-  
+
   test_that("Heterogeneity Estimates (tau) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_heterogeneityRE"]][["data"]]
     expect_equal_tables(table,
@@ -349,7 +349,7 @@ context("Meta Analysis - Selection Models")
                              0.00295522337136342, 2.97235752098961, "Adjusted", 1.44293003000819
                         ))
   })
-  
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_meanRE"]][["data"]]
     expect_equal_tables(table,
@@ -358,7 +358,7 @@ context("Meta Analysis - Selection Models")
                              -0.613990043882111, 0.623256252747511, 0.418043363607438, 0.491240647841718,
                              "Adjusted", 1.02470982941101))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_weightsRE"]][["data"]]
     expect_equal_tables(table,
@@ -367,7 +367,7 @@ context("Meta Analysis - Selection Models")
                              0.8, 0.368087005023669, 0, 0.8, 0.118743607281528, 0.235942792209477,
                              1.56006886913872, 0.83052638016606, 1))
   })
-  
+
   test_that("Test of Publication Bias table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
     expect_equal_tables(table,
@@ -375,13 +375,13 @@ context("Meta Analysis - Selection Models")
                              2, 3.27514663506786e-06, 25.2582958316257, "Assuming heterogeneity"
                         ))
   })
-  
+
   test_that("Test of Heterogeneity table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_heterogeneityTest"]][["data"]]
     expect_equal_tables(table,
                         list(99, 2.70555845478692e-05, 167.546611260491))
   })
-  
+
   test_that("p-value Frequency table results match", {
     table <- results[["results"]][["pFrequency"]][["data"]]
     expect_equal_tables(table,
@@ -529,8 +529,8 @@ context("Meta Analysis - Selection Models")
       row.names = c(NA,-13L)
     )
   results <- jaspTools::runAnalysis("SelectionModels", dataset, options)
-  
-  
+
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_meanFE"]][["data"]]
     expect_equal_tables(table,
@@ -540,7 +540,7 @@ context("Meta Analysis - Selection Models")
                              0.0490513224329791, -7.37299608003413, "Adjusted", -0.265516382656145
                         ))
   })
-  
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_meanRE"]][["data"]]
     expect_equal_tables(table,
@@ -549,7 +549,7 @@ context("Meta Analysis - Selection Models")
                              -0.688255571057507, 0.484951130715548, 0.545540765687672, 0.698361526307738,
                              "Adjusted", 1.45022493463498))
   })
-  
+
   test_that("Test of Publication Bias table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
     expect_equal_tables(table,
@@ -557,13 +557,13 @@ context("Meta Analysis - Selection Models")
                              1, 3.83999830480277e-05, 16.9488792381323, "Assuming heterogeneity"
                         ))
   })
-  
+
   test_that("Test of Heterogeneity table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_heterogeneityTest"]][["data"]]
     expect_equal_tables(table,
                         list(12, 4.44385100747795e-28, 163.194038293184))
   })
-  
+
   test_that("p-value Frequency table results match", {
     table <- results[["results"]][["pFrequency"]][["data"]]
     expect_equal_tables(table,
@@ -584,8 +584,8 @@ context("Meta Analysis - Selection Models")
   options$tablePVal <- TRUE
   set.seed(1)
   results <- jaspTools::runAnalysis("SelectionModels", "debug", options)
-  
-  
+
+
   test_that("Mean Estimates (mu) table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_meanFE"]][["data"]]
     expect_equal_tables(table,
@@ -594,7 +594,7 @@ context("Meta Analysis - Selection Models")
                              4.47036589833477e-263, 0.050087882861576, 34.6499780541257,
                              "Adjusted", 0.675800956676966))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_weightsFE"]][["data"]]
     expect_equal_tables(table,
@@ -602,23 +602,23 @@ context("Meta Analysis - Selection Models")
                              0.0136167098971546, 0.166039750266065, 2.46721886875839, 0.735088335343878,
                              1))
   })
-  
+
   test_that("Heterogeneity Estimates (tau) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_heterogeneityRE"]][["data"]]
     expect_equal_tables(table,
                         list(0, 0, 1, 0, "Unadjusted", 0.256968421344323, 0, 0, 1, 0, "Adjusted",
                              0.263359366452577))
   })
-  
+
   test_that("Mean Estimates (rho) table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_meanRE"]][["data"]]
     expect_equal_tables(table,
-                        list(0.662597315593418, 0.642091807205727, 1.85168846263159e-296, 0.0480800583300569,
+                        list(0.662597315593418, 0.642091807205727, 1.85168846263159e-296, 0.0101003960406904,
                              36.7999202587027, "Unadjusted", 0.681714072749364, 0.655407161618698,
-                             0.63347147760193, 4.55117028865932e-263, 0.0500886296911645,
+                             0.63347147760193, 4.55117028865932e-263, 0.0107901074740218,
                              34.6494614767693, "Adjusted", 0.67580125035602))
   })
-  
+
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_weightsRE"]][["data"]]
     expect_equal_tables(table,
@@ -626,7 +626,7 @@ context("Meta Analysis - Selection Models")
                              0.0140717065240502, 0.166837120624669, 2.45542767568545, 0.7366512310222,
                              1))
   })
-  
+
   test_that("Test of Publication Bias table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
     expect_equal_tables(table,
@@ -634,13 +634,13 @@ context("Meta Analysis - Selection Models")
                              1, 0.022329078915696, 5.21995889074792, "Assuming heterogeneity"
                         ))
   })
-  
+
   test_that("Test of Heterogeneity table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_heterogeneityTest"]][["data"]]
     expect_equal_tables(table,
                         list(99, 0.99117220635564, 69.5499359806442))
   })
-  
+
   test_that("p-value Frequency table results match", {
     table <- results[["results"]][["pFrequency"]][["data"]]
     expect_equal_tables(table,

--- a/tests/testthat/test-selectionmodels.R
+++ b/tests/testthat/test-selectionmodels.R
@@ -578,72 +578,78 @@ context("Meta Analysis - Selection Models")
   options$heterogeneityRE <- TRUE
   options$weightsRE <- TRUE
   options$cutoffsPVal <- "(.05, .10)"
-  options$inputES <- "debCollin1"
-  options$inputN <- "facFifty"
+  options$inputES <- "es"
+  options$inputN <- "n"
   options$measures <- "correlation"
   options$tablePVal <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("SelectionModels", "debug", options)
+  dataset <- data.frame(
+    es = runif(100, .1, .3),
+    n  = rnbinom(100, 200, .5)
+  )
+  results <- jaspTools::runAnalysis("SelectionModels", dataset, options)
 
 
-  test_that("Mean Estimates (mu) table results match", {
+  test_that("Mean Estimates table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_meanFE"]][["data"]]
-    expect_equal_tables(table,
-                        list(0.662597315593419, 0.642551263321564, 0, 0.0470387015263903, 37.6146078689525,
-                             "Unadjusted", 0.681314124633779, 0.655407160977405, 0.633471815965987,
-                             4.47036589833477e-263, 0.050087882861576, 34.6499780541257,
-                             "Adjusted", 0.675800956676966))
+    jaspTools::expect_equal_tables(table,
+                                   list(0.204177965488621, 0.190993378036, 1.59205580346668e-187, 0.00669934469245971,
+                                        29.2067466964043, "Unadjusted", 0.217252375590527, 0.195163279975223,
+                                        0.176695769355625, 2.8851502702737e-89, 0.00937139161237495,
+                                        20.0322183701612, "Adjusted", 0.213425528679819))
   })
 
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesFE"]][["collection"]][["estimatesFE_weightsFE"]][["data"]]
-    expect_equal_tables(table,
-                        list(1, 1, 0, 0, 1, 0.025, 0.409656404820366, 0.0842244742968537, 0.025,
-                             0.0136167098971546, 0.166039750266065, 2.46721886875839, 0.735088335343878,
-                             1))
+    jaspTools::expect_equal_tables(table,
+                                   list(1, 1, 0, 0, 1, 0.025, 0.946505734640249, 0.180360120650839, 0.025,
+                                        0.0154623999208921, 0.390897802221199, 2.42136366401121, 1.71265134862966,
+                                        0.05, 0.424477454915518, 0.00516906460893385, 0.05, 0.0472418366269367,
+                                        0.213936783335834, 1.98412562952852, 0.843785845222102, 1))
   })
 
-  test_that("Heterogeneity Estimates (tau) table results match", {
+  test_that("Heterogeneity Estimates table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_heterogeneityRE"]][["data"]]
-    expect_equal_tables(table,
-                        list(0, 0, 1, 0, "Unadjusted", 0.256968421344323, 0, 0, 1, 0, "Adjusted",
-                             0.263359366452577))
+    jaspTools::expect_equal_tables(table,
+                                   list(0, 0, 1, 0, "Unadjusted", 0.103411887992993, 0, 0, 1, 0, "Adjusted",
+                                        0.2426036713353))
   })
 
-  test_that("Mean Estimates (rho) table results match", {
+  test_that("Mean Estimates table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_meanRE"]][["data"]]
-    expect_equal_tables(table,
-                        list(0.662597315593418, 0.642091807205727, 1.85168846263159e-296, 0.0101003960406904,
-                             36.7999202587027, "Unadjusted", 0.681714072749364, 0.655407161618698,
-                             0.63347147760193, 4.55117028865932e-263, 0.0107901074740218,
-                             34.6494614767693, "Adjusted", 0.67580125035602))
+    jaspTools::expect_equal_tables(table,
+                                   list(0.204177965488621, 0.190991487999372, 1.79846926082398e-187, 0.00670030120287679,
+                                        29.2025772484021, "Unadjusted", 0.217254234170054, 0.195163505879826,
+                                        0.0875521107541049, 0.000447334225995675, 0.0534773308147392,
+                                        3.51045873910709, "Adjusted", 0.296177427245501))
   })
 
   test_that("Estimated Weights table results match", {
     table <- results[["results"]][["estimatesRE"]][["collection"]][["estimatesRE_weightsRE"]][["data"]]
-    expect_equal_tables(table,
-                        list(1, 1, 0, 0, 1, 0.025, 0.409656483313485, 0.0826617356047691, 0.025,
-                             0.0140717065240502, 0.166837120624669, 2.45542767568545, 0.7366512310222,
-                             1))
+    jaspTools::expect_equal_tables(table,
+                                   list(1, 1, 0, 0, 1, 0.025, 0.946521152729813, 0, 0.025, 0.436970853703284,
+                                        1.21767472715722, 0.777318549543651, 3.3331197628426, 0.05,
+                                        0.424482984589334, 0, 0.05, 0.748207603440691, 1.32236174634355,
+                                        0.321003678277194, 3.01626438195619, 1))
   })
 
   test_that("Test of Publication Bias table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
-    expect_equal_tables(table,
-                        list(1, 0.0223290789156104, 5.21995889075458, "Assuming homogeneity",
-                             1, 0.022329078915696, 5.21995889074792, "Assuming heterogeneity"
-                        ))
+    jaspTools::expect_equal_tables(table,
+                                   list(2, 0.175586023767488, 3.4792523845, "Assuming homogeneity", 2,
+                                        0.175586023955723, 3.47925238235592, "Assuming heterogeneity"
+                                   ))
   })
 
   test_that("Test of Heterogeneity table results match", {
     table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_heterogeneityTest"]][["data"]]
-    expect_equal_tables(table,
-                        list(99, 0.99117220635564, 69.5499359806442))
+    jaspTools::expect_equal_tables(table,
+                                   list(99, 0.998589436447844, 62.9827988030128))
   })
 
   test_that("p-value Frequency table results match", {
     table <- results[["results"]][["pFrequency"]][["data"]]
-    expect_equal_tables(table,
-                        list(89, 0, 0.025, 11, 0.025, 1))
+    jaspTools::expect_equal_tables(table,
+                                   list(86, 0, 0.025, 8, 0.025, 0.05, 6, 0.05, 1))
   })
 }

--- a/tests/testthat/test-waapwlspetpeese.R
+++ b/tests/testthat/test-waapwlspetpeese.R
@@ -1,0 +1,238 @@
+context("Meta Analysis - WAAP-WLS & PET-PEESE")
+
+### output for all default settings
+{
+  options <- analysisOptions("WaapWlsPetPeese")
+  options$estimatesPetPeese <- TRUE
+  options$estimatesSigma <- TRUE
+  options$inputES <- "contNormal"
+  options$inputSE <- "contGamma"
+  options$plotModels <- TRUE
+  options$regressionPeese <- TRUE
+  options$regressionPet <- TRUE
+  set.seed(1)
+  results <- runAnalysis("WaapWlsPetPeese", "debug.csv", options)
+
+
+  test_that("Mean Estimates(Î¼) table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_estimatesMean"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(99, -0.108777577319913, -0.317460586839519, 0.309438604923354,
+                                        0.106472879688439, -1.02164586548442, "WLS", 0.0999054321996926,
+                                        "WAAP", 98, -0.0534372106989058, -0.365542508416515, 0.737908055107035,
+                                        0.159240322873, -0.33557587509744, "PET", 0.258668087018703,
+                                        98, -0.099522276001487, -0.320999247127621, 0.380622055857872,
+                                        0.113000531067467, -0.880723967058771, "PEESE", 0.121954695124647
+                                   ))
+  })
+
+  test_that("Multiplicative Heterogeneity Estimates table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_heterogeneity"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(1.30091891089807, "WLS", 1.30607530257008, "PET", 1.30710817871426,
+                                        "PEESE"))
+  })
+
+  test_that("PET-PEESE Regression Estimates table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_petPeese"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(98, -0.0912254002529703, -0.472565404562442, 0.640204641058565,
+                                        0.194564801862398, -0.468868980307587, "PET", 0.290114604056502,
+                                        98, -0.0138169763943549, -0.120304772731226, 0.799789900219542,
+                                        0.0543315066893236, -0.254308728697008, "PEESE", 0.0926708199425164
+                                   ))
+  })
+
+  test_that("Test of Publication Bias table results match", {
+    table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(98, 0.640204641058565, -0.468868980307587, "PET"))
+  })
+
+  test_that("Test of Effect table results match", {
+    table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_effectTest"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(99, 0.309438604923354, -1.02164586548442, "WLS", "WAAP", 98, 0.737908055107035,
+                                        -0.33557587509744, "PET"))
+  })
+
+  test_that("Estimated PEESE Regression plot matches", {
+    plotName <- results[["results"]][["peeseRegression"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test1-estimated-peese-regression")
+  })
+
+  test_that("Estimated PET Regression plot matches", {
+    plotName <- results[["results"]][["petRegression"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test1-estimated-pet-regression")
+  })
+
+  test_that("Mean Model Estimates (Î¼) plot matches", {
+    plotName <- results[["results"]][["plotEstimates"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test1-mean-model-estimates-î-")
+  })
+}
+
+### correlation input
+{
+  options <- analysisOptions("WaapWlsPetPeese")
+  options$estimatesPetPeese <- TRUE
+  options$estimatesSigma <- TRUE
+  options$inputES <- "es"
+  options$inputN <- "n"
+  options$measures <- "correlation"
+  options$plotModels <- TRUE
+  options$regressionPeese <- TRUE
+  options$regressionPet <- TRUE
+  set.seed(1)
+  dataset <- data.frame(
+    es = runif(100, .1, .3),
+    n  = rnbinom(100, 200, .5)
+  )
+  results <- runAnalysis("WaapWlsPetPeese", dataset, options)
+
+
+  test_that("Mean Estimates(Ï) table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_estimatesMean"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(99, 0.204494800935266, 0.194003420566749, 5.26148520294194e-60,
+                                        0.00528471740121733, 37.2105528788957, "WLS", 0.214939408964263,
+                                        74, 0.207788715062346, 0.195955387443811, 1.8221078673566e-46,
+                                        0.00595663896635116, 33.5010375224788, "WAAP", 0.219561535437517,
+                                        98, 0.257973623720358, 0.047088822495066, 0.0195398509124503,
+                                        0.0922805546423889, 2.3741172881047, "PET", 0.427634849559746,
+                                        98, 0.23278815316705, 0.12946176384105, 4.42134957919393e-05,
+                                        0.0486358563634502, 4.27608870403368, "PEESE", 0.326248496575007
+                                   ))
+  })
+
+  test_that("Multiplicative Heterogeneity Estimates table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_heterogeneity"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(0.783705550212468, "WLS", 0.782952688284678, "WAAP", 0.786466872404923,
+                                        "PET", 0.786202556619872, "PEESE"))
+  })
+
+  test_that("PET-PEESE Regression Estimates table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_petPeese"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(98, -0.885634178219958, -4.02338359417463, 0.58138452359721, 1.60092197647755,
+                                        -0.553202586529912, "PET", 2.25211523773471, 98, -6.78354497523552,
+                                        -28.5781699135719, 0.543250003765216, 11.1199109321649, -0.610035909155872,
+                                        "PEESE", 15.0110799631009))
+  })
+
+  test_that("Test of Publication Bias table results match", {
+    table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(98, 0.58138452359721, -0.553202586529912, "PET"))
+  })
+
+  test_that("Test of Effect table results match", {
+    table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_effectTest"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(99, 5.26148520294194e-60, 37.2105528788957, "WLS", 74, 1.8221078673566e-46,
+                                        33.5010375224788, "WAAP", 98, 0.0195398509124503, 2.3741172881047,
+                                        "PET"))
+  })
+
+  test_that("Estimated PEESE Regression plot matches", {
+    plotName <- results[["results"]][["peeseRegression"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test2-estimated-peese-regression")
+  })
+
+  test_that("Estimated PET Regression plot matches", {
+    plotName <- results[["results"]][["petRegression"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test2-estimated-pet-regression")
+  })
+
+  test_that("Mean Model Estimates (Ï) plot matches", {
+    plotName <- results[["results"]][["plotEstimates"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test2-mean-model-estimates-ï-")
+  })
+}
+{
+  options <- analysisOptions("WaapWlsPetPeese")
+  options$estimatesPetPeese <- TRUE
+  options$estimatesSigma <- TRUE
+  options$inputES <- "es"
+  options$inputN <- "n"
+  options$measures <- "correlation"
+  options$muTransform <- "cohensD"
+  options$plotModels <- TRUE
+  options$regressionPeese <- TRUE
+  options$regressionPet <- TRUE
+  set.seed(1)
+  dataset <- data.frame(
+    es = runif(100, .1, .3),
+    n  = rnbinom(100, 200, .5)
+  )
+  results <- runAnalysis("WaapWlsPetPeese", dataset, options)
+
+  test_that("Mean Estimates(Ï) table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_estimatesMean"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(99, 0.204177965488621, 0.193670346059103, 2.31975858627933e-59,
+                                        0.00534349865123354, 36.6175938716485, "WLS", 0.214615485800175,
+                                        74, 0.206226772290166, 0.194360875622359, 9.01931583618286e-46,
+                                        0.00603147013438606, 32.7376328111126, "WAAP", 0.218002385351795,
+                                        98, 0.0668210463696642, -0.0477142481674846, 0.254539518103992,
+                                        0.0570007362484864, 1.14611237250867, "PET", 0.169485506372986,
+                                        98, 0.0862988609408255, 0.0303359606087919, 0.00346914004315054,
+                                        0.027736105328418, 2.99556512966557, "PEESE", 0.138359498977251
+                                   ))
+  })
+
+  test_that("Multiplicative Heterogeneity Estimates table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_heterogeneity"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(0.797615124542611, "WLS", 0.797164547505541, "WAAP", 0.800090187034191,
+                                        "PET", 0.800399326247497, "PEESE"))
+  })
+
+  test_that("PET-PEESE Regression Estimates table results match", {
+    table <- results[["results"]][["estimates"]][["collection"]][["estimates_petPeese"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(98, 1.02921858640322, -2.20742285810834, 0.534569165363249, 1.65137802022984,
+                                        0.623248325819407, "PET", 4.26586003091477, 98, 3.20292121854694,
+                                        -8.02767588530821, 0.577454674891103, 5.73000177168594, 0.558973861818639,
+                                        "PEESE", 14.4335183224021))
+  })
+
+  test_that("Test of Publication Bias table results match", {
+    table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_biasTest"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(98, 0.534569165363249, 0.623248325819407, "PET"))
+  })
+
+  test_that("Test of Effect table results match", {
+    table <- results[["results"]][["fitTests"]][["collection"]][["fitTests_effectTest"]][["data"]]
+    jaspTools::expect_equal_tables(table,
+                                   list(99, 2.31975858627933e-59, 36.6175938716485, "WLS", 74, 9.01931583618286e-46,
+                                        32.7376328111126, "WAAP", 98, 0.254539518103992, 1.14611237250867,
+                                        "PET"))
+  })
+
+  test_that("Estimated PEESE Regression plot matches", {
+    plotName <- results[["results"]][["peeseRegression"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test3-estimated-peese-regression")
+  })
+
+  test_that("Estimated PET Regression plot matches", {
+    plotName <- results[["results"]][["petRegression"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test3-estimated-pet-regression")
+  })
+
+  test_that("Mean Model Estimates (Ï) plot matches", {
+    plotName <- results[["results"]][["plotEstimates"]][["data"]]
+    testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+    jaspTools::expect_equal_plots(testPlot, "test3-mean-model-estimates-ï-")
+  })
+}


### PR DESCRIPTION
- adds WAAP-WLS & PET-PEESE analyses
- improves documentation in selection models
- fixes the standard errors of transformed effect size estimates not being transformed to the original scale in cases (in cases when correlations were supplied as input)

Also separates the transformations from the selection models, so they can be shared with the WAAP-WLS & PET-PEESE.
 
(RoBMA unit tests will fail - need the https://github.com/jasp-stats/jaspMetaAnalysis/pull/35 to me merged)

I think that we need better handling of effect size transformations across the whole module. I can imagine having two separate analyses. One dedicated to **effect size computations**, e.g., from the sample sizes, means, sds, ..., and another one dedicated to **effect size transformations** between different effect size estimates (I have already implemented convenience functions for this in RoBMA 2.0). Together, the effect size computation & transformations could be handled outside of the individual analyses. Then, we could easily add a dropdown specifying what kind of input did the user choose and whether he wants the out to be transformed to a different standardized scale - it would simplify the input menus, especially in the modules where I implemented the possibility to supply correlations or/and log(OR) as input.
(I will copy this comment to a separate issue).