### PR TITLE
Bayesian Meta-Analysis - Fix plot labels & enable advanced settings CRE & fix sequential plot

### DIFF
--- a/R/bayesianmetaanalysiscommon.R
+++ b/R/bayesianmetaanalysiscommon.R
@@ -351,8 +351,7 @@
                                        tau = tau,
                                        logml = logml,
                                        logml_iter = logml_iter,
-                                       iter = iter, ## TEMP!!!!
-                                       # iter = 10000 # because of an issue with stored variables, it is not yet possible to make it reactive.
+                                       iter = iter,
                                        chains = chains
       )
     })

--- a/R/bayesianmetaanalysiscommon.R
+++ b/R/bayesianmetaanalysiscommon.R
@@ -1762,20 +1762,21 @@
 
 .bmaFillSeqPM <- function(seqPMPlot, jaspResults, dataset, options, .bmaDependencies){
   n     <- nrow(dataset)
-  x     <- 0:n
-  x     <- x[-2]
-  dfPMP <- data.frame(prob = 0, g = rep(c("FE0", "FE1", "RE0", "RE1"), each = n))
+  x     <- rep(0:n, each = 4)
+  g     <- rep(c("FE0", "FE1", "RE0", "RE1"), n + 1)
+
   bmaResults     <- .bmaResultsState(jaspResults, dataset, options, .bmaDependencies)
   pM    <- bmaResults[["models"]]$prior
-  
-  dfPMP[c(1, 1 + n, 1 + 2*n, 1 + 3*n), 1] <- pM
+  pM    <- c(pM, pM) # x = 1 should be same as x = 0 as there are no results for when there is only 1 study
   
   rowResults <- .bmaSequentialResults(jaspResults, dataset, options, .bmaDependencies)
   
-  for(i in 2:nrow(dataset)){
+  for(i in 2:n){
     posterior_models <- rowResults$posterior_models[[i]]
-    dfPMP[c(i, i + n, i + 2*n, i + 3*n), 1] <- posterior_models
+    pM <- c(pM, posterior_models)
   }
+
+  dfPMP <- data.frame(x = x, y = pM, g = g)
   
   if(options[["modelSpecification"]] == "BMA" || options[["modelSpecification"]] == "CRE"){
     
@@ -1821,8 +1822,7 @@
     linetype    = rep("dashed", 5),
     size        = 0.85)
   
-  df <- data.frame(x = x, y = dfPMP$prob, g = dfPMP$g)
-  plot <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y, colour = g, linetype = g)) +
+  plot <- ggplot2::ggplot(dfPMP, ggplot2::aes(x = x, y = y, colour = g, linetype = g)) +
     gridLines + 
     ggplot2::geom_line(size = 1.5) +
     ggplot2::scale_y_continuous(limits = c(0,1.05), breaks = c(0, .25, .5, .75, 1)) +

--- a/inst/qml/qml_components/BayesianMetaAnalysisAdvanced.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisAdvanced.qml
@@ -33,18 +33,24 @@ Section
 		id:			priorModelProbabilityGroup
 		title: 		qsTr("Prior model probability")
 
-		property double fixedEffectsHypothesisVal:	modelTypeValue == "FE" ? 0.5 :
-														modelTypeValue == "RE" ? 0 :
-															modelTypeValue == "BMA" ? 0.25 : 0
+		property double fixedEffectsHypothesisVal:		modelTypeValue == "FE" ? 0.5 :
+															modelTypeValue == "RE" ? 0 :
+																modelTypeValue == "BMA" ? 0.25 : 0.25
 
-		property double randomEffectsHypothesisVal:	modelTypeValue == "FE" ? 0 :
-														modelTypeValue == "RE" ? 0.5 :
-															modelTypeValue == "BMA" ? 0.25 : 0
+		property double randomEffectsNullHypothesisVal:	modelTypeValue == "FE" ? 0 :
+															modelTypeValue == "RE" ? 0.5 :
+																modelTypeValue == "BMA" ? 0.25 : 0
+
+		property double randomEffectsAltHypothesisVal:	modelTypeValue == "FE" ? 0 :
+															modelTypeValue == "RE" ? 0.5 :
+																modelTypeValue == "BMA" ? 0.25 : 0.25
+
+		
 		function resetHypotheses() {
 			priorH0FE.value = fixedEffectsHypothesisVal
 			priorH1FE.value = fixedEffectsHypothesisVal
-			priorH0RE.value = randomEffectsHypothesisVal
-			priorH1RE.value = randomEffectsHypothesisVal
+			priorH0RE.value = randomEffectsNullHypothesisVal
+			priorH1RE.value = randomEffectsAltHypothesisVal
 
 			priorH0FE.editingFinished()
 			priorH1FE.editingFinished()
@@ -87,7 +93,7 @@ Section
 				name: 			"priorH0RE"
 				enabled: 		modelTypeValue == "RE" || modelTypeValue == "BMA"
 				label: 			"H\u2080"
-				defaultValue: 	priorModelProbabilityGroup.randomEffectsHypothesisVal
+				defaultValue: 	priorModelProbabilityGroup.randomEffectsNullHypothesisVal
 			}
 
 			DoubleField
@@ -95,7 +101,7 @@ Section
 				id: 			priorH1RE
 				name: 			"priorH1RE"
 				label: 			"H\u2081"
-				defaultValue: 	priorModelProbabilityGroup.randomEffectsHypothesisVal
+				defaultValue: 	priorModelProbabilityGroup.randomEffectsAltHypothesisVal
 			}
 		}
 
@@ -115,7 +121,7 @@ Section
 	}
 
 	Group
-	{
+	{		
 		Group
 		{
 			title: 		qsTr("Estimation settings (MCMC)")

--- a/inst/qml/qml_components/BayesianMetaAnalysisAdvanced.qml
+++ b/inst/qml/qml_components/BayesianMetaAnalysisAdvanced.qml
@@ -31,7 +31,6 @@ Section
 	Group
 	{
 		id:			priorModelProbabilityGroup
-		enabled: 	modelTypeValue == "FE" || modelTypeValue == "RE" || modelTypeValue == "BMA"
 		title: 		qsTr("Prior model probability")
 
 		property double fixedEffectsHypothesisVal:	modelTypeValue == "FE" ? 0.5 :
@@ -55,7 +54,7 @@ Section
 		
 		Group
 		{
-			enabled: 			modelTypeValue == "FE" || modelTypeValue == "BMA"
+			enabled: 			modelTypeValue == "FE" || modelTypeValue == "BMA" || modelTypeValue == "CRE"
 			title: 				qsTr("Fixed effects")
 			onEnabledChanged: 	priorModelProbabilityGroup.resetHypotheses()
 
@@ -79,13 +78,14 @@ Section
 		Group
 		{
 			title: 				qsTr("Random effects")
-			enabled: 			modelTypeValue == "RE" || modelTypeValue == "BMA"
+			enabled: 			modelTypeValue == "RE" || modelTypeValue == "BMA" || modelTypeValue == "CRE"
 			onEnabledChanged: 	priorModelProbabilityGroup.resetHypotheses()
 
 			DoubleField
 			{
 				id: 			priorH0RE
 				name: 			"priorH0RE"
+				enabled: 		modelTypeValue == "RE" || modelTypeValue == "BMA"
 				label: 			"H\u2080"
 				defaultValue: 	priorModelProbabilityGroup.randomEffectsHypothesisVal
 			}
@@ -98,12 +98,24 @@ Section
 				defaultValue: 	priorModelProbabilityGroup.randomEffectsHypothesisVal
 			}
 		}
+
+		Group
+		{
+			title: 				qsTr("Ordered effects")
+			visible: 			modelTypeValue == "CRE"
+
+			DoubleField
+			{
+				id: 			priorH1CRE
+				name: 			"priorH1CRE"
+				label: 			"H\u2081"
+				defaultValue: 	0.25
+			}
+		}
 	}
 
 	Group
 	{
-		enabled: !(modelTypeValue == "CRE")
-
 		Group
 		{
 			title: 		qsTr("Estimation settings (MCMC)")


### PR DESCRIPTION
This pull request adjusts the labels for sequential Bayes factor plots and posterior model probabilities plot for the constrained random effects model, see [#1527](https://github.com/jasp-stats/jasp-test-release/issues/1527).

Moreover, I enabled the advanced settings for this model as they finally work (there was a problem with the `metaBMA` package before). (this should also make the reviewing easier, as you can now decrease the number of iterations and chains to make it go faster)

Also, I fixed an issue with the posterior model probabilities plot where the probabilities for when there is only 1 study should be the same as the prior probabilities (same as with 0 studies) as the analysis does not work with only 1 study.