### PR TITLE
Classical and Bayesian

### DIFF
--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -14,8 +14,15 @@ Description
 	website:		"jasp-stats.org"
 	license:		"GPL (>= 2)"
 
+	GroupTitle
+	{
+		title:	qsTr("Classical")
+		icon:	"meta-analysis.svg"
+	}
+
 	Analysis
 	{
+		menu:			qsTr("Meta-Analysis")
 		title:			qsTr("Classical Meta-Analysis")
 		func:			"ClassicalMetaAnalysis"
 		requiresData:	true
@@ -28,10 +35,15 @@ Description
 		requiresData:	true
 	}
 
-	Separator{}
+	GroupTitle
+	{
+		title: 	qsTr("Bayesian")
+		icon:	"meta-analysis-bayesian.svg"
+	}
 
 	Analysis
 	{
+		menu:			qsTr("Meta-Analysis")
 		title:			qsTr("Bayesian Meta-Analysis")
 		func:			"BayesianMetaAnalysis"
 		requiresData:	true


### PR DESCRIPTION
This does not necessarily need to be in the new release but it was bugging me for a while (and I always forgot to fix it). 

For some reason, Meta-Analysis does not follow the "Classical" and "Bayesian" separation....

The old look:
![image](https://user-images.githubusercontent.com/38475991/132212794-fcc733d9-8763-48a4-9ee3-54810ef64e84.png)


The updated look:
![image](https://user-images.githubusercontent.com/38475991/132212530-a25966b2-96d3-4db0-bc24-57592487b8b2.png)
