### PR TITLE
remove dependency on outdated GitHub BayesTools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,5 +30,4 @@ Imports:
   ggmcmc
 Remotes:
   jasp-stats/jaspBase,
-  jasp-stats/jaspGraphs,
-  FBartos/BayesTools@3095a6d0f80348b8e274cb2e03f31c3d5f118f0b
+  jasp-stats/jaspGraphs


### PR DESCRIPTION
The new version of RoBMA crashes the analysis due to version mismatch. Installing BayesTools from CRAN should resolve the issue.

![image](https://user-images.githubusercontent.com/38475991/140901663-2d2294fa-e45d-4ced-be60-bcb8c694530e.png)
