### PR TITLE
fix influence measures error

### DIFF
--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -472,7 +472,7 @@
 
 .metaAnalysisCasewiseFill <- function(container, dataset, options) {
   rma.fit       <- .metaAnalysisComputeModel(container, dataset, options, ready = TRUE)
-  influ <- influence(rma.fit)
+  influ         <- metafor::influence.rma.uni(rma.fit)
   influenceVals <- influ$inf
   isInfluential <- influ$is.infl
   


### PR DESCRIPTION
fixes: https://github.com/jasp-stats/jasp-test-release/issues/1727
fixes: https://github.com/jasp-stats/jasp-test-release/issues/1722

The metafor namespace was not loaded properly when the fit object was already fitted and only accessed from JASP state. Calling the influence function from metafor package directly solves the issue.