### PR TITLE
changes from a review

### DIFF
--- a/R/waapwlspetpeese.R
+++ b/R/waapwlspetpeese.R
@@ -406,7 +406,7 @@
   # PET-PEESE estimates
   if (type == "petPeese") {
     if (is.null(estimates[["petPeese"]]) && options[["estimatesPetPeese"]]) {
-      petPeese <- createJaspTable(title = gettext("PET-PEESE Regression Estimates"))
+      petPeese <- createJaspTable(title = gettext("Regression Estimates"))
       petPeese$position  <- 2
       petPeese$dependOn("estimatesPetPeese")
       estimates[["petPeese"]] <- petPeese

--- a/inst/help/PetPeese.md
+++ b/inst/help/PetPeese.md
@@ -26,7 +26,7 @@ PET-PEESE is usually used as conditional estimator. PET is used to test for the 
 #### Mean Estimates
 Summarizes the mean effect size estimates.
 
-#### PET-PEESE Regression Estimates
+#### Regression Estimates
 Summarizes the regression coefficients of the relationship between effect sizes and standard errors (PET) and effect sizes and standard errors squared (PEESE).
 
 #### Multiplicative Heterogeneity Estimates

--- a/inst/help/RobustBayesianMetaAnalysis.md
+++ b/inst/help/RobustBayesianMetaAnalysis.md
@@ -17,12 +17,10 @@ The input supplied as standardized effect sizes are internally transformed to Fi
 - Fitted model: Specify a path to already fitted RoBMA model using R. The model must be saved as an RDS file.
 
 #### Data
-- Effect Size: Effect sizes of the studies. In case that the effect sizes are measured by Cohen's d t-statistics can be provided instead.
-- t-statistic: t-statistics of the studies. Only possible if the studies effect sizes are measured by Cohen's d or correlations. Effect sizes can be provided instead. 
+- Effect Size: Effect sizes of the studies.
 - Effect Size Standard Error: Standard errors of the effect sizes per study. Must always be positive. A 95% CI for the effect sizes can be provided instead. In case that the effect sizes are measured by Cohen's d the sample sizes can be provided instead.
 - 95% CI Lower and Upper Bound: 95% CI lower and upper bounds of the effect sizes per study. Must be separated into two columns. The standard errors of the effect sizes can be provided instead.
-- N: Overall sample sizes of the studies. Only possible if the studies effect sizes are measured by Cohen's d or correlations. Effect Size Standard Errors can be provided instead. In the case of two-sample t-tests, sample sizes per group can be provided as well.
-- N (group 1) / N (group 2): Sample sizes of each group of the studies. Only possible if the studies effect sizes are measured by Cohen's d and correspond to two-sample t-tests. Overall sample sizes or Effect Size Standard Errors can be provided instead.
+- N: Overall sample sizes of the studies. Only possible if the studies effect sizes are measured by Cohen's d or correlations. Effect Size Standard Errors can be provided instead.
 - Study Labels: Optional argument that will add study labels to the output.
 
 #### Expected direction of effect sizes
@@ -242,7 +240,7 @@ Balances the prior model probability across models with the same combinations of
 ---
 - Maier, M., Bartoš, F., & Wagenmakers, E. J. (in press). Robust Bayesian meta-analysis: Addressing publication bias with model-averaging. Psychological Methods. https://doi.org/10.31234/osf.io/u4cns
 - Bartoš, F., Maier, M., Wagenmakers, E. J., Doucouliagos, H., & Stanley, T. D. (2021). No need to choose: Robust Bayesian meta-analysis with competing publication bias adjustment methods. https://doi.org/10.31234/osf.io/kvsp7
-- Bartoš, F., Maier, M., & Wagenmakers, E. J. (2020). Adjusting for publication bias in JASP — selection models and robust Bayesian meta-analysis. https://doi.org/10.31234/osf.io/75bqn
+- Bartoš, F., Maier, M., Quintana, D. S., & Wagenmakers, E. J. (2020). Adjusting for publication bias in JASP & R — selection models, PET-PEESE, and robust Bayesian meta-analysis. https://doi.org/10.31234/osf.io/75bqn
 
 ### R-packages
 ---

--- a/inst/qml/PetPeese.qml
+++ b/inst/qml/PetPeese.qml
@@ -119,7 +119,7 @@ Form
 						
 			CheckBox
 			{
-				text:		qsTr("PET-PEESE regression estimates")
+				text:		qsTr("Regression estimates")
 				name:		"estimatesPetPeese"
 				checked:	false
 			}

--- a/inst/qml/qml_components/RobustBayesianMetaAnalysisPriors.qml
+++ b/inst/qml/qml_components/RobustBayesianMetaAnalysisPriors.qml
@@ -73,11 +73,11 @@ ColumnLayout
 			else if (componentType == "heterogeneityNull")
 				[{"type": "spike"}]
 			else if (componentType == "pet")
-				[{"type": "cauchy", "priorWeights": "1/4"}]
+				[{"type": "cauchy", "priorWeight": "1/4"}]
 			else if (componentType == "petNull")
 				[]
 			else if (componentType == "peese")
-				[{"type": "cauchy", "parScale2": "5", "priorWeights": "1/4"}]
+				[{"type": "cauchy", "parScale2": "5", "priorWeight": "1/4"}]
 			else if (componentType == "peeseNull")
 				[]
 		}

--- a/inst/qml/qml_components/RobustBayesianMetaAnalysisWeightfunctions.qml
+++ b/inst/qml/qml_components/RobustBayesianMetaAnalysisWeightfunctions.qml
@@ -55,12 +55,12 @@ ColumnLayout
 		{
 			if (componentType == "omega")
 				[
-					{"type": "two-sided",	"parCuts": "(.05)",				"parAlpha": "(1,1)",	"priorWeights": "1/12"},
-					{"type": "two-sided",	"parCuts": "(.05, .10)",		"parAlpha": "(1,1,1)",	"priorWeights": "1/12"},
-					{"type": "one-sided",	"parCuts": "(.05)",				"parAlpha": "(1,1)",	"priorWeights": "1/12"},
-					{"type": "one-sided",	"parCuts": "(.025, .05)",		"parAlpha": "(1,1,1)",	"priorWeights": "1/12"},
-					{"type": "one-sided",	"parCuts": "(.05, .50)",		"parAlpha": "(1,1,1)",	"priorWeights": "1/12"},
-					{"type": "one-sided",	"parCuts": "(.025, .05, .10)",	"parAlpha": "(1,1,1,1)","priorWeights": "1/12"}
+					{"type": "two-sided",	"parCuts": "(.05)",				"parAlpha": "(1,1)",	"priorWeight": "1/12"},
+					{"type": "two-sided",	"parCuts": "(.05, .10)",		"parAlpha": "(1,1,1)",	"priorWeight": "1/12"},
+					{"type": "one-sided",	"parCuts": "(.05)",				"parAlpha": "(1,1)",	"priorWeight": "1/12"},
+					{"type": "one-sided",	"parCuts": "(.025, .05)",		"parAlpha": "(1,1,1)",	"priorWeight": "1/12"},
+					{"type": "one-sided",	"parCuts": "(.05, .50)",		"parAlpha": "(1,1,1)",	"priorWeight": "1/12"},
+					{"type": "one-sided",	"parCuts": "(.025, .05, .10)",	"parAlpha": "(1,1,1,1)","priorWeight": "1/12"}
 				]
 			else if (componentType == "omegaNull")
 				[{"type": "none"}]


### PR DESCRIPTION
Minimal changes:
- removing description of obsolete items from help files
- removing duplicitous PET-PEESE name from the regression estimates name
- making default model weights for custom model correspond to RoBMA-PSMA settings (previous default settings was incorrectly passed due to a typo in the parameter name)