### PR TITLE
Do not use visible property to set another property

### DIFF
--- a/R/bayesianmetaanalysiscommon.R
+++ b/R/bayesianmetaanalysiscommon.R
@@ -471,11 +471,11 @@
   bmaTable$dependOn(options = c(.bmaDependencies, "bayesFactorType"))
 
   if (options$bayesFactorType == "BF10")
-    bfTitle <- gettextf("BF%s%s", "\u2081", "\u2080")
+    bfTitle <- "BF\u2081\u2080"
   else if (options$bayesFactorType == "BF01")
-    bfTitle <- gettextf("BF%s%s", "\u2080", "\u2081")
+    bfTitle <- "BF\u2080\u2081"
   else
-    bfTitle <- gettextf("Log(BF%s%s)", "\u2081", "\u2080")
+    bfTitle <- "Log(BF\u2081\u2080)"
 
   # Add columns
   bmaTable$addColumnInfo(name = "model", title = "", type = "string", combine = TRUE)

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -286,8 +286,8 @@
   casewiseTable$addColumnInfo(name = "dfFits", type = "number",  title = gettext("DFFITS"))
   casewiseTable$addColumnInfo(name = "cook",   type = "number",  title = gettext("Cook's Distance"))
   casewiseTable$addColumnInfo(name = "cov",    type = "number",  title = gettext("Cov. Ratio"))
-  casewiseTable$addColumnInfo(name = "tau2",   type = "number",  title = gettextf("%s%s<sub>(-i)</sub>", "\u3C4", "\u00B2"))
-  casewiseTable$addColumnInfo(name = "QE",     type = "number",  title = gettext("Q<sub>E(-i)</sub>"))
+  casewiseTable$addColumnInfo(name = "tau2",   type = "number",  title = "\u3C4\u00B2<sub>(-i)</sub>"
+  casewiseTable$addColumnInfo(name = "QE",     type = "number",  title = "Q<sub>E(-i)</sub>"
   casewiseTable$addColumnInfo(name = "hat",    type = "number",  title = gettext("Hat"))
   casewiseTable$addColumnInfo(name = "weight", type = "number",  title = gettext("Weight"))
 

--- a/inst/qml/PetPeese.qml
+++ b/inst/qml/PetPeese.qml
@@ -49,22 +49,22 @@ Form
 
 		AssignedVariablesList
 		{
+			id:				inputSE
 			name:			"inputSE"
 			title:			qsTr("Effect Size Standard Error")
 			singleVariable:	true
 			allowedColumns:	["scale"]
 			visible:		 measuresGeneral.checked
-			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
 		}
 
 		AssignedVariablesList
 		{
+			id:				inputN
 			name: 			"inputN"
 			title: 			qsTr("N")
 			singleVariable: true
 			allowedColumns: ["scale", "ordinal"]
 			visible:		 measuresCorrelation.checked
-			onVisibleChanged: if (!measuresGeneral.checked && count > 0) itemDoubleClicked(0);
 		}
 
 		DropDown
@@ -91,6 +91,7 @@ Form
 			value: "general"
 			id: 	measuresGeneral
 			checked:true
+			onCheckedChanged: if (!checked && inputSE.count > 0) inputSE.itemDoubleClicked(0);
 		}
 
 		RadioButton
@@ -98,6 +99,7 @@ Form
 			label: qsTr("Correlations & N")
 			value: "correlation"
 			id: 	measuresCorrelation
+			onCheckedChanged: if (!checked && inputN.count > 0) inputN.itemDoubleClicked(0);
 		}
 	}
 

--- a/inst/qml/SelectionModels.qml
+++ b/inst/qml/SelectionModels.qml
@@ -47,22 +47,22 @@ Form
 
 		AssignedVariablesList
 		{
+			input:			inputSE
 			name:			"inputSE"
 			title:			qsTr("Effect Size Standard Error")
 			singleVariable:	true
 			allowedColumns:	["scale"]
 			visible:		 measures_general.checked
-			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
 		}
 
 		AssignedVariablesList
 		{
+			id:				inputN
 			name: 			"inputN"
 			title: 			qsTr("N")
 			singleVariable: true
 			allowedColumns: ["scale", "ordinal"]
 			visible:		 measures_correlation.checked
-			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
 		}
 
 		AssignedVariablesList
@@ -85,6 +85,7 @@ Form
 			value: "general"
 			id: 	measures_general
 			checked:true
+			onCheckedChanged: if (!checked && inputSE.count > 0) inputSE.itemDoubleClicked(0);
 		}
 
 		RadioButton
@@ -92,6 +93,7 @@ Form
 			label: qsTr("Correlations & N")
 			value: "correlation"
 			id: 	measures_correlation
+			onCheckedChanged: if (!checked && inputN.count > 0) inputN.itemDoubleClicked(0);
 		}
 	}
 

--- a/inst/qml/WaapWls.qml
+++ b/inst/qml/WaapWls.qml
@@ -49,22 +49,22 @@ Form
 
 		AssignedVariablesList
 		{
+			id:				inputSE
 			name:			"inputSE"
 			title:			qsTr("Effect Size Standard Error")
 			singleVariable:	true
 			allowedColumns:	["scale"]
 			visible:		 measuresGeneral.checked
-			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
 		}
 
 		AssignedVariablesList
 		{
+			id:				inputN
 			name: 			"inputN"
 			title: 			qsTr("N")
 			singleVariable: true
 			allowedColumns: ["scale", "ordinal"]
 			visible:		 measuresCorrelation.checked
-			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
 		}
 
 		DropDown
@@ -91,6 +91,7 @@ Form
 			value: "general"
 			id: 	measuresGeneral
 			checked:true
+			onCheckedChanged: if (!checked && inputSE.count > 0) inputSE.itemDoubleClicked(0);
 		}
 
 		RadioButton
@@ -98,6 +99,7 @@ Form
 			label: qsTr("Correlations & N")
 			value: "correlation"
 			id: 	measuresCorrelation
+			onCheckedChanged: if (!checked && inputN.count > 0) inputN.itemDoubleClicked(0);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2131
Don't use the visible property or the onVisibleChanged signal: this visibility is set not only when a control is set to invisible with a binding, but also if the whole form becomes hidden.