### PR TITLE
Fix coefficient test and CI

### DIFF
--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -84,7 +84,7 @@
       data    = dataset,
       test    = options$estimateTest,
       # add tiny amount because 1 is treated by rma() as 100% whereas values > 1 as percentages
-      level   = options$coefficientCiLevel + 1e-9,
+      level   = options$coefficientCiLevel * 100,
       control = list(maxiter = 500)
     )
     argList <- argList[!sapply(argList, is.null)]

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -139,11 +139,16 @@
   coeffTable$addColumnInfo(name = "name",  type = "string", title = "")
   coeffTable$addColumnInfo(name = "est",   type = "number", title = gettext("Estimate"))
   coeffTable$addColumnInfo(name = "se",    type = "number", title = gettext("Standard Error"))
-  coeffTable$addColumnInfo(name = "zval",  type = "number", title = gettext("z"))
+  if (options[["estimateTest"]] == "z")
+    coeffTable$addColumnInfo(name = "zval",  type = "number", title = gettext("z"))
+  else if (options[["estimateTest"]] == "knha") {
+    coeffTable$addColumnInfo(name = "tval",  type = "number", title = gettext("t"))
+    coeffTable$addColumnInfo(name = "df",    type = "number", title = gettext("df"))
+  }
   coeffTable$addColumnInfo(name = "pval",  type = "pvalue", title = gettext("p"))
   .metaAnalysisConfidenceInterval(options, coeffTable)
 
-  coeffTable$addFootnote(switch(options$estimateTest, z = gettext("Wald test."), gettext("Wald tests.")))
+  coeffTable$addFootnote(switch(options$estimateTest, z = gettext("Wald test."), knha = gettext("Knapp and Hartung test adjustment.")))
 
   container[["coeffTable"]] <- coeffTable
   if(!ready)
@@ -353,16 +358,31 @@
   rma.fit <- .metaAnalysisComputeModel(container, dataset, options, ready = TRUE)
   coeff   <- coef(summary(rma.fit))
 
-  for (i in 1:nrow(coeff)) {
-    container[["coeffTable"]]$addRows(list(
-      name  = .metaAnalysisMakePrettyCoeffNames(rownames(coeff)[i], dataset),
-      est   = coeff[i,1],
-      se    = coeff[i,2],
-      zval  = coeff[i,3],
-      pval  = coeff[i,4],
-      lower = coeff[i,5],
-      upper = coeff[i,6]
-    ))
+  if (options[["estimateTest"]] == "z") {
+    for (i in 1:nrow(coeff)) {
+      container[["coeffTable"]]$addRows(list(
+        name  = .metaAnalysisMakePrettyCoeffNames(rownames(coeff)[i], dataset),
+        est   = coeff[i,"estimate"],
+        se    = coeff[i,"se"],
+        zval  = coeff[i,"zval"],
+        pval  = coeff[i,"pval"],
+        lower = coeff[i,"ci.lb"],
+        upper = coeff[i,"ci.ub"]
+      ))
+    }
+  } else if (options[["estimateTest"]] == "knha") {
+    for (i in 1:nrow(coeff)) {
+      container[["coeffTable"]]$addRows(list(
+        name  = .metaAnalysisMakePrettyCoeffNames(rownames(coeff)[i], dataset),
+        est   = coeff[i,"estimate"],
+        se    = coeff[i,"se"],
+        tval  = coeff[i,"tval"],
+        df    = coeff[i,"df"],
+        pval  = coeff[i,"pval"],
+        lower = coeff[i,"ci.lb"],
+        upper = coeff[i,"ci.ub"]
+      ))
+    }
   }
 }
 

--- a/inst/qml/qml_components/ClassicalMetaAnalysisStatistics.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisStatistics.qml
@@ -40,9 +40,9 @@ Section
 				id: estimatesConfInt
 				name: "coefficientCi"; text: qsTr("Confidence intervals")
 				CIField { name: "coefficientCiLevel"; label: qsTr("Interval") }
-				DropDown { name: "estimateTest"; label: qsTr("Test"); values: [ "z", "knha"]; }
 			}
 		}
+		DropDown { name: "estimateTest"; label: qsTr("Test"); values: [ "z", "knha"]; }
 		CheckBox { name: "covarianceMatrix"; text: qsTr("Covariance matrix") }
 
 	}


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2314

Uses correct metafor specification for CI

Note that the previous implementation of `estimateTest` was not really correct
- it should not be nested within `coefficientCi`
- `knha` should report "t" and "df" (previously, df was put in place of p-value)