### PR TITLE
fixes non-functioning diagnostics plots

### DIFF
--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -511,7 +511,7 @@
 # Plots
 .metaAnalysisPlotsContainer <- function(container, options, ready)  {
   if(!ready) return()
-  if(!options$forestPlot && !options$funnelPlot && !options$plotResidualseffectSize &&
+  if(!options$forestPlot && !options$funnelPlot && !options$diagnosticPlot &&
      !options$profilePlot && !options$trimFillAnalysis)
     return()
   if (is.null(container[["plots"]])) {


### PR DESCRIPTION
fixes: https://github.com/jasp-stats/jasp-test-release/issues/2315
(this was introduced in options renaming)

What does not make sense is why both the 
`Trim-fill analysis` and `Diagnostic plots` produce the very same output. I would expect the `Trim-fill analysis` to produce actual Trim-fill analysis. Could you fix that in a separate PR?