### PR TITLE
Update DESCRIPTION to use RoBMA v3.0.1 from GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,5 @@ Imports:
   pema
 Remotes:
   jasp-stats/jaspBase,
-  jasp-stats/jaspGraphs
+  jasp-stats/jaspGraphs,
+  FBartos/RoBMA@v3.0.1


### PR DESCRIPTION
since the CRAN version got yeeted.