### PR TITLE
Hotfix for RoBMA

### DIFF
--- a/R/robustbayesianmetaanalysis.R
+++ b/R/robustbayesianmetaanalysis.R
@@ -950,7 +950,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
 
   ### create overview table
   modelsSummary <- createJaspTable(title = gettext("Models Overview"))
-  modelsSummary$position <- 6
+  modelsSummary$position <- 8
   modelsSummary$dependOn(c(.robmaDependencies, "bayesFactorType", "inferenceModelsOverview", "inferenceModelsOverviewBF", "inferenceModelsOverviewOrder", "inferenceShortenPriorName"))
   jaspResults[["mainSummary"]][["modelsSummary"]] <- modelsSummary
 
@@ -1032,7 +1032,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     return()
   } else {
     individualModels <- createJaspContainer(title = gettext("Individual Models Summary"))
-    individualModels$position <- 5
+    individualModels$position <- 9
     individualModels$dependOn(c(.robmaDependencies, "bayesFactorType", "inferenceIndividualModels", "inferenceIndividualModelsSingleModel", "inferenceIndividualModelsSingleModelNumber", "inferenceShortenPriorName", "inferenceOutputScale"))
     jaspResults[["individualModels"]] <- individualModels
   }
@@ -1193,7 +1193,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   width  <- 800
 
   forestPlot <- createJaspPlot(title = title, width = width, height = height)
-  forestPlot$position <- 6
+  forestPlot$position <- 10
   forestPlot$dependOn(c(.robmaDependencies, "plotsForestPlot", "plotsForestPlotOrder", "plotsForestPlotType", "inferenceOutputScale"))
   jaspResults[["forestPlot"]] <- forestPlot
 
@@ -1222,7 +1222,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # create / access the container
   if (is.null(jaspResults[["estimatesPlots"]])) {
     estimatesPlots <- createJaspContainer(title = gettext("Posterior Distribution Plots"))
-    estimatesPlots$position <- 7
+    estimatesPlots$position <- 11
     estimatesPlots$dependOn(c(.robmaDependencies, "plotsPooledEstimatesType", "plotsPooledEstimatesPriorDistribution", "inferenceOutputScale"))
     jaspResults[["estimatesPlots"]] <- estimatesPlots
   } else {
@@ -1306,7 +1306,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # create / access the container
   if (is.null(jaspResults[["modelsPlots"]])) {
     modelsPlots <- createJaspContainer(title = gettext("Posterior Model Estimates Plots"))
-    modelsPlots$position <- 8
+    modelsPlots$position <- 12
     modelsPlots$dependOn(c(.robmaDependencies, "plotsIndividualModelsType", "plotsIndividualModelsOrder", "plotsIndividualModelsOrderBy", "plotsIndividualModelsShowBayesianUpdating", "plotsIndividualModelsShowPosteriorEstimates", "inferenceOutputScale"))
     jaspResults[["modelsPlots"]] <- modelsPlots
   } else {
@@ -1394,7 +1394,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # create / access the container
   if (is.null(jaspResults[["diagnostics"]])) {
     diagnostics <- createJaspContainer(title = gettext("Diagnostics"))
-    diagnostics$position <- 9
+    diagnostics$position <- 13
     diagnostics$dependOn(.robmaDependencies)
     jaspResults[["diagnostics"]] <- diagnostics
   } else {
@@ -1457,7 +1457,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # create / access the container
   if (is.null(jaspResults[["diagnostics"]])) {
     diagnostics <- createJaspContainer(title = gettext("Diagnostics"))
-    diagnostics$position <- 9
+    diagnostics$position <- 14
     diagnostics$dependOn(.robmaDependencies)
     jaspResults[["diagnostics"]] <- diagnostics
   } else {

--- a/R/robustbayesianmetaanalysis.R
+++ b/R/robustbayesianmetaanalysis.R
@@ -1576,7 +1576,10 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
           title         = FALSE
         )
 
-        if (is.null(newPlots))
+        # (temporal) fix for the package returning a list with empty plots on the remaining spots
+        newPlots <- newPlots[!sapply(newPlots, is.null)]
+
+        if (length(newPlots) == 0)
           next
 
         noPars <- FALSE
@@ -1620,7 +1623,10 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
           title         = FALSE
         )
 
-        if (is.null(newPlots))
+        # (temporal) fix for the package returning a list with empty plots on the remaining spots
+        newPlots <- newPlots[!sapply(newPlots, is.null)]
+
+        if (length(newPlots) == 0)
           next
 
         noPars <- FALSE
@@ -1665,7 +1671,10 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
           title         = FALSE
         )
 
-        if (is.null(newPlots))
+        # (temporal) fix for the package returning a list with empty plots on the remaining spots
+        newPlots <- newPlots[!sapply(newPlots, is.null)]
+
+        if (length(newPlots) == 0)
           next
 
         noPars <- FALSE

--- a/inst/qml/RobustBayesianMetaAnalysis.qml
+++ b/inst/qml/RobustBayesianMetaAnalysis.qml
@@ -379,7 +379,7 @@ Form
 					{ label: qsTr("Cohen's d"),			value: "cohensD"},
 					{ label: qsTr("Fisher's z"),		value: "fishersZ"},
 					{ label: qsTr("logOR"),				value: "logOr"},
-					{ label: qsTr("Correlation"),		value: "r"}
+					{ label: qsTr("Correlation"),		value: "correlation"}
 				]
 			}
 

--- a/inst/qml/RobustBayesianMetaAnalysis.qml
+++ b/inst/qml/RobustBayesianMetaAnalysis.qml
@@ -578,7 +578,7 @@ Form
 
 			RadioButtonGroup
 			{
-				name: 		"plotsIndividualModelsOrderelsOrderBy"
+				name: 		"plotsIndividualModelsOrder"
 				title:		qsTr("Order")
 
 				RadioButton


### PR DESCRIPTION
Fixes the following errors in 18.0
- incorrectly ordered output tables/figures (probably present for a longer time)
- errors while producing MCMC diagnostic plots (due to different structure of the plot output from the updated package)
- inability to display the output as a correlation coefficients (due to wrongly named option from names recoding for syntax)
- inability to produce individual model plots (due to wrongly named option from names recoding for syntax)