### PR TITLE
Add Subgroup Analyses

### DIFF
--- a/R/classicalmetaanalysis.R
+++ b/R/classicalmetaanalysis.R
@@ -67,6 +67,9 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   "forestPlotStudyInformationStudyWeights",
   "forestPlotStudyInformationOrderBy",
   "forestPlotStudyInformationOrderAscending",
+  "forestPlotStudyInformationAggregateBy",
+  "forestPlotStudyInformationAggregateMethod",
+  "forestPlotStudyInformationAggregateMethodBubbleRelativeSize",
   "forestPlotEstimatedMarginalMeans",
   "forestPlotEstimatedMarginalMeansModelVariables",
   "forestPlotEstimatedMarginalMeansSelectedVariables",
@@ -89,6 +92,7 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   "forestPlotPredictionIntervals",
   "forestPlotEstimatesAndConfidenceIntervals",
   "forestPlotTestsInRightPanel",
+  "forestPlotAllignLeftPanel",
   "forestPlotSubgroupPanelsWithinSubgroup",
   "forestPlotSubgroupFullDatasetEstimatedMarginalMeans",
   "forestPlotSubgroupFullDatasetModelInformation",
@@ -138,6 +142,7 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
 .maDataPlottingDependencies <- c(
   "forestPlotStudyInformationSelectedVariables",
   "forestPlotStudyInformationOrderBy",
+  "forestPlotStudyInformationAggregateBy",
   "forestPlotMappingColor",
   "forestPlotMappingShape"
 )

--- a/R/classicalmetaanalysis.R
+++ b/R/classicalmetaanalysis.R
@@ -156,7 +156,8 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   )
   anyNaByRows <- apply(dataset[,omitOnVariables], 1, function(x) anyNA(x))
   dataset     <- dataset[!anyNaByRows,]
-  attr(dataset, "NAs") <- sum(anyNaByRows)
+  attr(dataset, "NAs")    <- sum(anyNaByRows)
+  attr(dataset, "NasIds") <- anyNaByRows
 
   # drop empty factor levels
   dataset <- droplevels(dataset)

--- a/R/classicalmetaanalysis.R
+++ b/R/classicalmetaanalysis.R
@@ -57,6 +57,7 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   "computeCovarianceMatrix", "computeCovarianceMatrix"
 )
 .maForestPlotDependencies <- c(
+  # do not forget to add variable carrying options to the .maDataPlottingDependencies
   .maDependencies, "transformEffectSize", "confidenceIntervalsLevel",
   "forestPlotStudyInformation",
   "forestPlotStudyInformationAllVariables",
@@ -88,6 +89,9 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   "forestPlotPredictionIntervals",
   "forestPlotEstimatesAndConfidenceIntervals",
   "forestPlotTestsInRightPanel",
+  "forestPlotSubgroupPanelsWithinSubgroup",
+  "forestPlotSubgroupFullDatasetEstimatedMarginalMeans",
+  "forestPlotSubgroupFullDatasetModelInformation",
   "forestPlotMappingColor",
   "forestPlotMappingShape",
   "forestPlotRelativeSizeEstimates",
@@ -130,6 +134,12 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   "bubblePlotTheme",
   "bubblePlotLegendPosition",
   "bubblePlotRelativeSizeText"
+)
+.maDataPlottingDependencies <- c(
+  "forestPlotStudyInformationSelectedVariables",
+  "forestPlotStudyInformationOrderBy",
+  "forestPlotMappingColor",
+  "forestPlotMappingShape"
 )
 .maReady               <- function(options) {
 

--- a/R/classicalmetaanalysis.R
+++ b/R/classicalmetaanalysis.R
@@ -32,7 +32,7 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
 }
 
 .maDependencies        <- c(
-  "effectSize", "effectSizeStandardError", "predictors", "predictors.types", "clustering", "method", "fixedEffectTest",
+  "effectSize", "effectSizeStandardError", "predictors", "predictors.types", "clustering", "subgroup", "method", "fixedEffectTest",
   "effectSizeModelTerms", "effectSizeModelIncludeIntercept",
   "clusteringUseClubSandwich", "clusteringSmallSampleCorrection",
   "confidenceIntervalsLevel",
@@ -150,6 +150,7 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
     options[["effectSize"]],
     options[["effectSizeStandardError"]],
     if (options[["clustering"]] != "") options[["clustering"]],
+    if (options[["subgroup"]] != "")   options[["subgroup"]],
     if (length(predictorsNominal) > 0) predictorsNominal,
     if (length(predictorsScale) > 0)   predictorsScale
   )

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -4785,12 +4785,12 @@
   messages <- NULL
 
   if (options[["clustering"]] == "") {
-    fit <- fit[[1]]
-    if (!jaspBase::isTryError(fit) && !is.null(fit)){
-      if (all(fit[["tcl"]][1] == fit[["tcl"]]))
-        messages <- c(messages, gettextf("%1$i clusters with %2$i estimates each.", fit[["n"]],  fit[["tcl"]][1]))
+    tempFit <- fit[[1]]
+    if (!jaspBase::isTryError(tempFit) && !is.null(tempFit)){
+      if (all(tempFit[["tcl"]][1] == tempFit[["tcl"]]))
+        messages <- c(messages, gettextf("%1$i clusters with %2$i estimates each.", tempFit[["n"]],  tempFit[["tcl"]][1]))
       else
-        messages <- c(messages, gettextf("%1$i clusters with min/median/max %2$i/%3$i/%4$i estimates.", fit[["n"]],  min(fit[["tcl"]]), median(fit[["tcl"]]), max(fit[["tcl"]])))
+        messages <- c(messages, gettextf("%1$i clusters with min/median/max %2$i/%3$i/%4$i estimates.", tempFit[["n"]],  min(tempFit[["tcl"]]), median(tempFit[["tcl"]]), max(tempFit[["tcl"]])))
     }
   } else {
     for (i in seq_along(fit)) {
@@ -4830,7 +4830,7 @@
   if (!is.null(attr(dataset, "influentialObservations")) && attr(dataset, "influentialObservations") > 0)
     messages <- c(messages, gettextf("%1$i influential observations were detected and removed.", attr(dataset, "influentialObservations")))
 
-  if (.maIsMultilevelMultivariate(options) && any(attr(fit, "skipped")) && !jaspBase::isTryError(fit[[1]]))
+  if (.maIsMultilevelMultivariate(options) && any(attr(fit[[1]], "skipped")) && !jaspBase::isTryError(fit[[1]]))
     messages <- c(messages, gettextf("The Model Structure %1$s was not completely specified and was skipped.", paste0(which(attr(fit[[1]], "skipped")), collapse = " and ")))
 
   if (.mammAnyStructureGen(options) && options[["predictionIntervals"]])

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -789,7 +789,7 @@
   .maAddCiColumn(pooledEstimatesTable, options)
   .maAddPiColumn(pooledEstimatesTable, options)
   if (options[["predictionIntervals"]] && .mammHasMultipleHeterogeneities(options, canAddOutput = TRUE)) {
-    for (colName in .mammExtractTauLevelNames(fit)) {
+    for (colName in .mammExtractTauLevelNamesList(fit)) {
       pooledEstimatesTable$addColumnInfo(name = colName, title = colName, type = .maGetVariableColumnType(colName, options), overtitle = gettext("Heterogeneity Level"))
     }
   }
@@ -1254,7 +1254,7 @@
   if (parameter == "effectSize") {
     .maAddPiColumn(estimatedMarginalMeansTable, options)
     if (options[["predictionIntervals"]] && .mammHasMultipleHeterogeneities(options, canAddOutput = TRUE)) {
-      for (colName in .mammExtractTauLevelNames(fit)) {
+      for (colName in .mammExtractTauLevelNamesList(fit)) {
         estimatedMarginalMeansTable$addColumnInfo(name = colName, title = colName, type = .maGetVariableColumnType(colName, options), overtitle = gettext("Heterogeneity Level"))
       }
     }
@@ -1317,7 +1317,7 @@
     .maAddPiColumn(contrastsTable, options)
     # if (options[["predictionIntervals"]] && .mammHasMultipleHeterogeneities(options, canAddOutput = TRUE)) {
     #   TODO?
-    #   for (colName in .mammExtractTauLevelNames(fit)) {
+    #   for (colName in .mammExtractTauLevelNamesList(fit)) {
     #   contrastsTable$addColumnInfo(name = colName, title = colName, type = .maGetVariableColumnType(colName, options), overtitle = gettext("Heterogeneity Level"))
     #   }
     # }
@@ -4199,9 +4199,14 @@
 
   # pooled effect size
   row          <- .maComputePooledEffect(fit, options)
-  row$subgroup <- attr(fit, "subgroup")
 
-  row <- do.call(cbind.data.frame, row)
+  if (options[["predictionIntervals"]] && .mammHasMultipleHeterogeneities(options, canAddOutput = TRUE)) {
+    row <- do.call(rbind.data.frame, row)
+  } else {
+    row <- do.call(cbind.data.frame, row)
+  }
+
+  row$subgroup <- attr(fit, "subgroup")
   return(row)
 }
 .maRowPooledHeterogeneity             <- function(fit, options) {

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -3127,7 +3127,7 @@
   hasSeparateLines <- attr(dfPlot, "separateLines") != ""
   hasSeparatePlots <- attr(dfPlot, "separatePlots") != ""
 
-  ### add prediction bads
+  ### add prediction bands
   if (options[["bubblePlotPredictionIntervals"]]) {
 
     geomPi <- .maBubblePlotMakeCiGeom(dfPlot, options, ci = FALSE)

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -4042,7 +4042,7 @@
 }
 .maPrintDf                            <- function(df) {
   if (.maIsWholenumber(df)) {
-    return(sprintf("%1$i", df))
+    return(sprintf("%1$i", round(df)))
   } else {
     return(sprintf("%1$.2f", df))
   }

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -2157,10 +2157,19 @@
 
   # keep levels for which the heterogeneity is predicted for complex multivariate models
   if (.mammHasMultipleHeterogeneities(options, canAddOutput = TRUE) && options[["predictionIntervals"]]) {
-    tauLevels <- list(
-      predictedEffect[["tau2.level"]],
-      predictedEffect[["gamma2.level"]]
-    )
+    # if there is only a single level of heterogeneity, the levels are not returned
+    # happens with subgroups etc - it needs to be appended from the design matrix
+    if (nrow(tauLevelsMatrix) == 1) {
+      tauLevels <- list(
+        tauLevelsMatrix[["tau2.levels"]],
+        tauLevelsMatrix[["gamma2.levels"]]
+      )
+    } else {
+      tauLevels <- list(
+        predictedEffect[["tau2.level"]],
+        predictedEffect[["gamma2.level"]]
+      )
+    }
     tauLevels           <- do.call(cbind.data.frame, tauLevels[!sapply(tauLevels, is.null)])
     colnames(tauLevels) <- .mammExtractTauLevelNames(fit)
   }

--- a/R/classicalmetaanalysismultilevelmultivariate.R
+++ b/R/classicalmetaanalysismultilevelmultivariate.R
@@ -913,6 +913,19 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
 
   return(levelNames)
 }
+.mammExtractTauLevelNamesList    <- function(fit) {
+
+  levelNames <- list()
+
+  for (i in seq_along(fit)) {
+    if (jaspBase::isTryError(fit[[i]]) || is.null(fit[[i]]))
+      next
+    levelNames[[length(levelNames) + 1]] <- .mammExtractTauLevelNames(fit[[i]])
+  }
+
+  levelNames <- unique(unlist(levelNames))
+  return(levelNames)
+}
 .mammExtractTauLevels            <- function(fit, expanded = TRUE) {
 
   levels <- list()

--- a/R/classicalmetaanalysismultilevelmultivariate.R
+++ b/R/classicalmetaanalysismultilevelmultivariate.R
@@ -45,12 +45,14 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
     options[["effectSizeStandardError"]],
     unlist(randomVariables),
     if (options[["clustering"]] != "") options[["clustering"]],
+    if (options[["subgroup"]] != "")   options[["subgroup"]],
     if (length(predictorsNominal) > 0) predictorsNominal,
     if (length(predictorsScale) > 0)   predictorsScale
   )
   anyNaByRows <- apply(dataset[,omitOnVariables], 1, function(x) anyNA(x))
   dataset     <- dataset[!anyNaByRows,]
-  attr(dataset, "NAs") <- sum(anyNaByRows)
+  attr(dataset, "NAs")    <- sum(anyNaByRows)
+  attr(dataset, "NasIds") <- anyNaByRows
 
   # add se^2 for V^2 input
   dataset$samplingVariance <- dataset[[options[["effectSizeStandardError"]]]]^2
@@ -351,6 +353,7 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
 }
 .mammRandomEstimatesTable        <- function(jaspResults, dataset, options) {
 
+  # obtain the overall container
   if (!is.null(jaspResults[["randomEstimatesContainer"]])) {
     randomEstimatesContainer <- jaspResults[["randomEstimatesContainer"]]
   } else {
@@ -362,16 +365,45 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
 
   fit <- .maExtractFit(jaspResults, options)
 
+  if (options[["subgroup"]] == "") {
+
+    # directly fill the main container if only full estimate is requested
+    .mammRandomEstimatesTableFun(jaspResults, randomEstimatesContainer, options, fit[[1]])
+
+  } else {
+
+    for (i in seq_along(fit)) {
+
+      # create subgroup containers
+      if (!is.null(randomEstimatesContainer[[attr(fit[[i]], "subgroup")]])) {
+        randomEstimatesSubgroupContainer <- randomEstimatesContainer[[attr(fit[[i]], "subgroup")]]
+      } else {
+        randomEstimatesSubgroupContainer <- createJaspContainer(title = gettextf("Subgroup: %1$s", attr(fit[[i]], "subgroup")))
+        randomEstimatesSubgroupContainer$position <- 1
+        randomEstimatesContainer[[attr(fit[[i]], "subgroup")]] <- randomEstimatesSubgroupContainer
+      }
+
+      # fill the subgroup containers
+      .mammRandomEstimatesTableFun(jaspResults, randomEstimatesSubgroupContainer, options, fit[[i]])
+    }
+  }
+
+  return()
+}
+.mammRandomEstimatesTableFun     <- function(jaspResults, randomEffectsContainer, options, fit) {
+
+  dataset <- attr(fit, "dataset")
+
   # stop on error
   if (is.null(fit) || jaspBase::isTryError(fit) || !is.null(.maCheckIsPossibleOptions(options)))
     return()
 
   ### create table for nested random effects
-  if (fit[["withS"]] && is.null(randomEstimatesContainer[["containerS"]])) {
+  if (fit[["withS"]] && is.null(randomEffectsContainer[["containerS"]])) {
 
     containerS <- createJaspContainer(title = gettext("Simple / Nested Summary"))
     containerS$position <- 1
-    randomEstimatesContainer[["containerS"]] <- containerS
+    randomEffectsContainer[["containerS"]] <- containerS
 
     tableS <- createJaspTable(title = gettext("Estimates"))
     tableS$position <- 1
@@ -402,35 +434,35 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
   }
 
   ### create summary for the remaining types
-  if (fit[["withG"]] && is.null(randomEstimatesContainer[["containerG"]])) {
+  if (fit[["withG"]] && is.null(randomEffectsContainer[["containerG"]])) {
 
     # create jasp containers
     containerG <- createJaspContainer(title = .mammGetRandomEstimatesTitle(fit[["struct"]][1]))
     containerG$position <- 2
-    randomEstimatesContainer[["containerG"]] <- containerG
+    randomEffectsContainer[["containerG"]] <- containerG
     .mammExtractRandomTables(containerG, options, fit, indx = 1)
 
   }
 
-  if (fit[["withH"]] && is.null(randomEstimatesContainer[["containerH"]])) {
+  if (fit[["withH"]] && is.null(randomEffectsContainer[["containerH"]])) {
 
     containerH <- createJaspContainer(title = .mammGetRandomEstimatesTitle(fit[["struct"]][2]))
     containerH$position <- 3
-    randomEstimatesContainer[["containerH"]] <- containerH
+    randomEffectsContainer[["containerH"]] <- containerH
     .mammExtractRandomTables(containerH, options, fit, indx = 2)
 
   }
 
   ### create random structure confidence intervals summary
-  if (options[["randomEffectsConfidenceIntervals"]] && is.null(randomEstimatesContainer[["confidenceIntervalContainers"]]) && !is.null(.mammGetRandomFormulaList(options))) {
+  if (options[["randomEffectsConfidenceIntervals"]] && is.null(randomEffectsContainer[["confidenceIntervalContainers"]]) && !is.null(.mammGetRandomFormulaList(options))) {
 
     confidenceIntervalsContainer <- createJaspContainer(title = gettext("Confidence Intervals"))
     confidenceIntervalsContainer$position <- 4
     confidenceIntervalsContainer$dependOn(c("randomEffectsConfidenceIntervals", "confidenceIntervalsLevel"))
-    randomEstimatesContainer[["confidenceIntervalsContainer"]] <- confidenceIntervalsContainer
+    randomEffectsContainer[["confidenceIntervalsContainer"]] <- confidenceIntervalsContainer
 
     # extract precomputed confidence intervals
-    confintRandom <- .mammFitConfintRandom(jaspResults, options)
+    confintRandom <- .mammFitConfintRandom(jaspResults, options)[[attr(fit, "subgroup")]]
 
 
     # confidence intervals for nested/simple random effects
@@ -466,25 +498,24 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
 
 
   ### create random structure inclusion summary
-  if (options[["randomEffectsTestInclusion"]] && is.null(randomEstimatesContainer[["inclusionTestsContainer"]])) {
+  if (options[["randomEffectsTestInclusion"]] && is.null(randomEffectsContainer[["inclusionTestsContainer"]])) {
 
     inclusionTestsContainer <- createJaspContainer(title = gettext("Inclusion Tests"))
     inclusionTestsContainer$position <- 5
     inclusionTestsContainer$dependOn("randomEffectsTestInclusion")
-    randomEstimatesContainer[["inclusionTestsContainer"]] <- inclusionTestsContainer
+    randomEffectsContainer[["inclusionTestsContainer"]] <- inclusionTestsContainer
 
     ### table with general tests for component drop
     tableInclusion <- .mammMakeRandomInclusionTable(title = gettext("Component Inclusion Test"), position = 0)
     inclusionTestsContainer[["tableInclusion"]] <- tableInclusion
 
     # extract the precomputed drop models
-    dropOneFits    <- .mammFitDropOneRandom(jaspResults, options)
+    dropOneFits    <- .mammFitDropOneRandom(jaspResults, options)[[attr(fit, "subgroup")]]
 
     if (length(dropOneFits) == 0)
       return()
 
     # compute ANOVAs
-    fit      <- .maExtractFit(jaspResults, options)
     fitTests <- lapply(dropOneFits, function(fitB) data.frame(anova(fit, fitB)))
     fitTests <- rbind(
       cbind(model = "", fitTests[[1]][1,]),
@@ -499,7 +530,7 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
     if (fit[["withS"]]) {
 
       # extract the precomputed drop models
-      dropLevelFits <- .mammFitDropLevelRandom(jaspResults, options)
+      dropLevelFits <- .mammFitDropLevelRandom(jaspResults, options)[[attr(fit, "subgroup")]]
 
       for (i in seq_along(dropLevelFits)) {
 
@@ -511,7 +542,6 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
         levelsDropped <- sapply(1:nrow(levelsGrid), function(i) paste0(colnames(levelsGrid[!unlist(levelsGrid[i,])]), collapse = ", "))
 
         # compute ANOVAs
-        fit      <- .maExtractFit(jaspResults, options)
         fitTests <- lapply(dropLevelFits[[i]], function(fitB) data.frame(anova(fit, fitB)))
         fitTests <- rbind(
           cbind(model = "", fitTests[[1]][1,]),
@@ -562,21 +592,48 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
 }
 .mammFitDropOneRandom            <- function(jaspResults, options) {
 
-  if (!is.null(jaspResults[["dropOneFits"]]))
-    return(jaspResults[["dropOneFits"]]$object)
+  # extract precomputed drop one fits
+  if (!is.null(jaspResults[["dropOneFits"]])) {
 
-  dropOneFitsContainer <- createJaspState()
-  dropOneFitsContainer$dependOn(.maDependencies)
-  jaspResults[["dropOneFits"]] <- dropOneFitsContainer
+    out <- jaspResults[["dropOneFits"]]$object
 
-  fit <- .maExtractFit(jaspResults, options)
+  } else {
+
+    # create the output container
+    confintRandomContainer <- createJaspState()
+    confintRandomContainer$dependOn(.maDependencies)
+    jaspResults[["dropOneFits"]] <- confintRandomContainer
+
+    fit <- .maExtractFit(jaspResults, options)
+    out <- list()
+
+    for (i in seq_along(fit)) {
+      if (jaspBase::isTryError(fit[[i]])) {
+        out[[attr(fit[[i]], "subgroup")]] <- list()
+      } else {
+        out[[attr(fit[[i]], "subgroup")]] <- .mammFitDropOneRandomFun(fit[[i]], options)
+      }
+    }
+
+    jaspResults[["dropOneFits"]]$object <- out
+  }
+
+
+  return(out)
+}
+.mammFitDropOneRandomFun         <- function(fit, options) {
 
   # create list of all structures
   randomFormulaLists <- .mammGetRandomFormulaList(options)
   dropOneFits        <- vector("list", length = length(randomFormulaLists))
   names(dropOneFits) <- names(randomFormulaLists)
 
-  startProgressbar(expectedTicks = length(randomFormulaLists), label = gettext("Testing Inclusion of Random Effects / Model Structure"))
+  if (options[["subgroup"]] == "") {
+    startProgressbar(expectedTicks = length(randomFormulaLists), label = gettext("Testing Inclusion of Random Effects / Model Structure"))
+  } else {
+    startProgressbar(expectedTicks = length(randomFormulaLists), label = gettextf("Subgroup %1$s: Testing Inclusion of Random Effects / Model Structure", attr(fit, "subgroup")))
+  }
+
 
   # perform drop one re-estimation
   for (i in seq_along(randomFormulaLists)) {
@@ -606,19 +663,40 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
     progressbarTick()
   }
 
-  dropOneFitsContainer$object <- dropOneFits
   return(dropOneFits)
 }
 .mammFitDropLevelRandom          <- function(jaspResults, options) {
 
-  if (!is.null(jaspResults[["dropLevelFits"]]))
-    return(jaspResults[["dropLevelFits"]]$object)
+  # extract precomputed drop one fits
+  if (!is.null(jaspResults[["dropLevelFits"]])) {
 
-  dropLevelFitsContainer <- createJaspState()
-  dropLevelFitsContainer$dependOn(.maDependencies)
-  jaspResults[["dropLevelFits"]] <- dropLevelFitsContainer
+    out <- jaspResults[["dropLevelFits"]]$object
 
-  fit <- .maExtractFit(jaspResults, options)
+  } else {
+
+    # create the output container
+    confintRandomContainer <- createJaspState()
+    confintRandomContainer$dependOn(.maDependencies)
+    jaspResults[["dropLevelFits"]] <- confintRandomContainer
+
+    fit <- .maExtractFit(jaspResults, options)
+    out <- list()
+
+    for (i in seq_along(fit)) {
+      if (jaspBase::isTryError(fit[[i]])) {
+        out[[attr(fit[[i]], "subgroup")]] <- list()
+      } else {
+        out[[attr(fit[[i]], "subgroup")]] <- .mammFitDropLevelRandomFun(fit[[i]], options)
+      }
+    }
+
+    jaspResults[["dropLevelFits"]]$object <- out
+  }
+
+
+  return(out)
+}
+.mammFitDropLevelRandomFun       <- function(fit, options) {
 
   # create list of all structures & keep hierarchical structures
   randomFormulaLists             <- .mammGetRandomFormulaList(options)
@@ -636,7 +714,12 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
     tempLevelsGrid <- tempLevelsGrid[-c(1, nrow(tempLevelsGrid)), , drop = FALSE] # first and the last fits are the full and null models
     colnames(tempLevelsGrid) <- tempLevels
 
-    startProgressbar(expectedTicks = nrow(tempLevelsGrid), label = gettextf("Testing Inclusion of Nested Random Effects: %1$s", names(randomFormulaHierarchicalLists)[i]))
+    if (options[["subgroup"]] == "") {
+      startProgressbar(expectedTicks = nrow(tempLevelsGrid), label = gettextf("Testing Inclusion of Nested Random Effects: %1$s", names(randomFormulaHierarchicalLists)[i]))
+    } else {
+      startProgressbar(expectedTicks = nrow(tempLevelsGrid), label = gettextf("Subgroup %1$s: Testing Inclusion of Nested Random Effects: %2$s", attr(fit, "subgroup"), names(randomFormulaHierarchicalLists)[i]))
+    }
+
     dropOneFits <- list()
 
     for (j in 1:nrow(tempLevelsGrid)) {
@@ -673,23 +756,50 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
     attr(dropLevelsList[[i]], "levelsGrid") <- tempLevelsGrid
   }
 
-  dropLevelFitsContainer$object <- dropLevelsList
   return(dropLevelsList)
 }
 .mammFitConfintRandom            <- function(jaspResults, options) {
 
-  if (!is.null(jaspResults[["confintRandom"]]))
-    return(jaspResults[["confintRandom"]]$object)
+  # extract precomputed confidence intervals
+  if (!is.null(jaspResults[["confintRandom"]])) {
 
-  confintRandomContainer <- createJaspState()
-  confintRandomContainer$dependOn(.maDependencies)
-  jaspResults[["confintRandom"]] <- confintRandomContainer
+    out <- jaspResults[["confintRandom"]]$object
 
-  fit <- .maExtractFit(jaspResults, options)
+  } else {
+
+    # create the output container
+    confintRandomContainer <- createJaspState()
+    confintRandomContainer$dependOn(.maDependencies)
+    jaspResults[["confintRandom"]] <- confintRandomContainer
+
+    fit <- .maExtractFit(jaspResults, options)
+    out <- list()
+
+    for (i in seq_along(fit)) {
+      if (jaspBase::isTryError(fit[[i]])) {
+        out[[attr(fit[[i]], "subgroup")]] <- list()
+      } else {
+        out[[attr(fit[[i]], "subgroup")]] <- .mammFitConfintRandomFun(fit[[i]], options)
+      }
+    }
+
+    jaspResults[["confintRandom"]]$object <- out
+  }
+
+  return(out)
+}
+.mammFitConfintRandomFun         <- function(fit, options) {
+
+  if (options[["subgroup"]] == "") {
+    progressBarCode <- paste0("jaspBase::startProgressbar(",.mammConfintIterations(fit),", label = 'Random effects / model components: Confidence intervals')")
+  } else {
+    progressBarCode <- paste0("jaspBase::startProgressbar(",.mammConfintIterations(fit),", label = 'Subgroup ", attr(fit, "subgroup")," :Random effects / model components: Confidence intervals')")
+  }
+
   confintRandom <- confint(
     fit,
     level = 100 * options[["confidenceIntervalsLevel"]],
-    code1 = paste0("jaspBase::startProgressbar(",.mammConfintIterations(fit),", label = 'Random effects / model components: Confidence intervals')"),
+    code1 = progressBarCode,
     code2 = "jaspBase::progressbarTick()"
   )
 
@@ -704,7 +814,7 @@ ClassicalMetaAnalysisMultilevelMultivariate <- function(jaspResults, dataset = N
     cbind.data.frame(parameter = rownames(x[[1]]), data.frame(x[[1]]))
   }))
 
-  confintRandomContainer$object <- confintRandom
+
   return(confintRandom)
 }
 .mammGetStructureOptions         <- function(structure) {

--- a/R/forestplot.R
+++ b/R/forestplot.R
@@ -619,7 +619,7 @@
 
     ### tests and weights right panel
     rightPanelTestsAndWeights <- rbind(
-      if (options[["forestPlotStudyInformation"]] > 0 && options[["forestPlotStudyInformationStudyWeights"]]) {
+      if (options[["forestPlotStudyInformation"]] > 0 && options[["forestPlotStudyInformationStudyWeights"]] && options[["forestPlotStudyInformationAggregateBy"]] == "") {
         tempDf <- forestInformation[,c("y", "weights")]
         tempDf$label <- paste0(sprintf(paste0("%1$.", options[["forestPlotAuxiliaryDigits"]], "f"), tempDf$weights), " %")
         tempDf[,c("y", "label")]

--- a/R/forestplot.R
+++ b/R/forestplot.R
@@ -1,497 +1,230 @@
-.maMakeTheUltimateForestPlot <- function(fit, dataset, options) {
+.maMakeTheUltimateForestPlot <- function(fit, options) {
 
-  # extract common options
-  relativeRowSize <- options[["forestPlotRelativeSizeRow"]]
+  # in case of subgroups, reorder the fit objects so the subgroup output is first
+  if (options[["subgroup"]] != "") {
+    fit <- fit[c(2:length(fit), 1)]
+  }
+
+  # remove failed model
+  fit <- fit[!sapply(fit, jaspBase::isTryError)]
 
   # overwrite basic options used in the pooled effect/marginal means
   options[["confidenceIntervals"]] <- TRUE
   options[["predictionIntervals"]] <- options[["forestPlotPredictionIntervals"]]
 
-  # keep track of added rows across marginal means and model estimates:
+  ### initiate objects for generating the forest plot ----
+  forestInput                 <- list() # this list carries the study information
+  estimatedMarginalMeansInput <- list() # this list carries estimated marginal means information
+  modelInformationInput       <- list() # this list carries model information
+
+  ### create the inputs ----
+  for (i in seq_along(fit)) {
+
+    ### Study Information panel
+    if (options[["forestPlotStudyInformation"]]) {
+      forestInput[[names(fit)[i]]] <- .forestPlotBuildStudyInformation(fit[[i]], options)
+    }
+
+    ### Estimated marginal means panel
+    if (options[["forestPlotEstimatedMarginalMeans"]] &&
+        (length(options[["forestPlotEstimatedMarginalMeansSelectedVariables"]]) > 0 || options[["forestPlotEstimatedMarginalMeansAdjustedEffectSizeEstimate"]])) {
+      estimatedMarginalMeansInput[[names(fit)[i]]] <- .forestPlotBuildEstimatedMarginalMeans(fit[[i]], options)
+    }
+
+    ### Model information panel
+    if (options[["forestPlotModelInformation"]]) {
+      modelInformationInput[[names(fit)[i]]] <- .forestPlotBuildModelInformation(fit[[i]], options)
+    }
+
+  }
+
+  ### reorder the inputs ----
+  forestHeaderIndex     <- NULL
+  forestInformation     <- NULL
+  forestObjects         <- NULL
+  additionalInformation <- NULL
+  additionalObjects     <- NULL
   tempRow <- 1
-  additionalInformation <- list()
-  additionalObjects     <- list()
 
-  ### Study information panel ----
-  if (options[["forestPlotStudyInformation"]]) {
+  if (options[["subgroup"]] == "" || (options[["subgroup"]] != "" && options[["forestPlotSubgroupPanelsWithinSubgroup"]])) {
 
-    ### extract effect sizes and variances from the fitted object
-    dfForrest <- data.frame(
-      effectSize     = fit[["yi"]],
-      standardError  = sqrt(fit[["vi"]]),
-      weights        = weights(fit),
-      id             = seq_along(fit[["yi"]])
-    )
+    for (i in seq_along(fit)) {
 
-    # add CI using normal approximation
-    dfForrest$lCi <- dfForrest$effectSize - qnorm((1 - options[["confidenceIntervalsLevel"]]) / 2, lower.tail = F) * dfForrest$standardError
-    dfForrest$uCi <- dfForrest$effectSize + qnorm((1 - options[["confidenceIntervalsLevel"]]) / 2, lower.tail = F) * dfForrest$standardError
+      # skip individual sections in case a subgroup analysis is performed and we are at the full fit object
+      if (i == length(fit) && options[["subgroup"]] != "") {
+        doForest                 <- FALSE
+        doEstimatedMarginalMeans <- options[["forestPlotSubgroupFullDatasetEstimatedMarginalMeans"]]
+        doModelInformation       <- options[["forestPlotSubgroupFullDatasetModelInformation"]]
+      } else {
+        doForest                 <- TRUE
+        doEstimatedMarginalMeans <- TRUE
+        doModelInformation       <- TRUE
+      }
 
-    if (options[["forestPlotStudyInformationSecondaryConfidenceInterval"]]) {
-      dfForrest$lCi2 <- dfForrest$effectSize - qnorm((1 - options[["forestPlotStudyInformationSecondaryConfidenceIntervalLevel"]]) / 2, lower.tail = F) * dfForrest$standardError
-      dfForrest$uCi2 <- dfForrest$effectSize + qnorm((1 - options[["forestPlotStudyInformationSecondaryConfidenceIntervalLevel"]]) / 2, lower.tail = F) * dfForrest$standardError
-    }
+      # extract forest input
+      if (doForest && length(forestInput) > 0) {
 
-
-    # transform effect size when requested
-    if (options[["transformEffectSize"]] != "none") {
-
-      dfForrest[,c(
-        "effectSize", "lCi", "uCi",
-        if (options[["forestPlotStudyInformationSecondaryConfidenceInterval"]]) c("lCi2", "uCi2"))] <- do.call(
-          .maGetEffectSizeTransformationOptions(options[["transformEffectSize"]]),
-          list(dfForrest[,c(
-              "effectSize", "lCi", "uCi",
-              if (options[["forestPlotStudyInformationSecondaryConfidenceInterval"]]) c("lCi2", "uCi2"))]))
-    }
-
-    xRangeStudyInformationPanel <- range(c(dfForrest$lCi, dfForrest$uCi))
-
-    # add variables used for either color, shape, order or Left panel information
-    additionalVariables <- c(
-      if (length(options[["forestPlotStudyInformationSelectedVariables"]]) > 0) unlist(options[["forestPlotStudyInformationSelectedVariables"]]),
-      if (options[["forestPlotStudyInformationOrderBy"]] != "") options[["forestPlotStudyInformationOrderBy"]],
-      if (options[["forestPlotMappingColor"]] != "")            options[["forestPlotMappingColor"]],
-      if (options[["forestPlotMappingShape"]] != "")            options[["forestPlotMappingShape"]]
-    )
-    if (length(additionalVariables) > 0)
-      dfForrest <- cbind(dfForrest, dataset[,additionalVariables,drop=FALSE])
-
-    # TODO: temporal fix for the variable names in the Component list not being properly translated
-    for (i in seq_along(options[["forestPlotStudyInformationSelectedVariables"]])) {
-      options[["forestPlotStudyInformationSelectedVariablesSettings"]][[i]][["value"]] <- options[["forestPlotStudyInformationSelectedVariables"]][[i]]
-    }
-
-    # combine left panel information
-    leftPanelStudyInformation <- do.call(rbind.data.frame, options[["forestPlotStudyInformationSelectedVariablesSettings"]])
-
-    # re-order
-    if (options[["forestPlotStudyInformationOrderBy"]] != "") {
-      dfForrest <- dfForrest[order(
-        dfForrest[,options[["forestPlotStudyInformationOrderBy"]]],
-        decreasing = options[["forestPlotStudyInformationOrderAscending"]]),]
-    }
-
-    # add y-axis coordinates for plotting
-    dfForrest$row <- seq(nrow(dfForrest))
-
-    ### add predicted effects
-    if (options[["forestPlotStudyInformationPredictedEffects"]]) {
-
-      fitPrediction <- data.frame(predict(fit))
-
-      # replicate the prediction for each estimate if the predictions are the same (no moderators)
-      if (nrow(fitPrediction) == 1)
-        fitPrediction <- do.call(rbind, replicate(nrow(dfForrest), fitPrediction, simplify = FALSE))
-
-      fitPrediction$id   <- dfForrest$id
-      fitPrediction$row  <- dfForrest$row
-
-      # create prediction diamond coordinates for each estimate
-      fitPrediction <- do.call(rbind, lapply(1:nrow(fitPrediction), function(i) {
-        with(fitPrediction[i,], .maMakeDiamondDataFrame(est = pred, lCi = pi.lb, uCi = pi.ub, row = row, id = id))
-      }))
-
-      fitPrediction <- merge(fitPrediction, dfForrest[,!colnames(dfForrest) %in% c("effectSize", "standardError", "weights", "lCi", "uCi")], by = "id")
-
-      # transform effect size when requested
-      if (options[["transformEffectSize"]] != "none")
-        fitPrediction[,"xPrediction"] <- do.call(
-          .maGetEffectSizeTransformationOptions(options[["transformEffectSize"]]),
-          list(fitPrediction[,"xPrediction"]))
-
-      xRangeStudyInformationPanel <- range(c(xRangeStudyInformationPanel, range(fitPrediction$x)))
-
-      # adjust y-coordinates
-      fitPrediction$y <- fitPrediction$y * relativeRowSize
-    }
-
-    # adjust y-coordinates
-    dfForrest$y <- dfForrest$row * relativeRowSize
-
-  } else {
-    dfForrest <- NULL
-    xRangeStudyInformationPanel <- NA
-  }
-
-  ### Make sure no multiple prediction intervals are drawn for complex models ----
-  if (.mammHasMultipleHeterogeneities(options)) {
-    options[["predictionIntervals"]]           <- FALSE
-    options[["forestPlotPredictionIntervals"]] <- FALSE
-  }
-
-  ### Estimated marginal means panel ----
-
-  ### compute and add marginal estimates
-  if (options[["forestPlotEstimatedMarginalMeans"]] && (
-    length(options[["forestPlotEstimatedMarginalMeansSelectedVariables"]]) > 0 || options[["forestPlotEstimatedMarginalMeansAdjustedEffectSizeEstimate"]]
-  )) {
-
-    # terms and levels information
-    estimatedMarginalMeansTestsStaistics   <- options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue"
-    estimatedMarginalMeansVariables        <- unlist(options[["forestPlotEstimatedMarginalMeansSelectedVariables"]])
-
-    # statistics position adjustment
-    estimatedMarginalMeansTermsTestsRight  <- options[["forestPlotEstimatedMarginalMeansTermTests"]] && options[["forestPlotTestsInRightPanel"]]
-    estimatedMarginalMeansTermsTestsLeft   <- options[["forestPlotEstimatedMarginalMeansTermTests"]] && !options[["forestPlotTestsInRightPanel"]]
-
-    estimatedMarginalMeansCoefficientTestsRight <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && options[["forestPlotTestsInRightPanel"]]
-    estimatedMarginalMeansCoefficientTestsBelow <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && !options[["forestPlotTestsInRightPanel"]] && options[["forestPlotPredictionIntervals"]]
-    estimatedMarginalMeansCoefficientTestsLeft  <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && !options[["forestPlotTestsInRightPanel"]] && !options[["forestPlotPredictionIntervals"]]
-
-    # add header
-    additionalInformation[[tempRow]] <- data.frame(
-      "label"  = gettext("Estimated Marginal Means"),
-      "row"    = tempRow,
-      "est"    = NA,
-      "lCi"    = NA,
-      "uCi"    = NA,
-      "test"   = "",
-      "face"   = "bold"
-    )
-    tempRow <- tempRow + 1
-
-    # add marginal estimates
-    for (i in seq_along(estimatedMarginalMeansVariables)) {
-
-      tempTermTest               <- .maTermTests(fit, options, estimatedMarginalMeansVariables[i])
-      tempEstimatedMarginalMeans <- .maComputeMarginalMeansVariable(fit, options, dataset, estimatedMarginalMeansVariables[i], options[["forestPlotEstimatedMarginalMeansCoefficientTestsAgainst"]] , "effectSize")
-      tempTestText               <- .maPrintTermTest(tempTermTest, estimatedMarginalMeansTestsStaistics)
-
-      # add term information
-      additionalInformation[[tempRow]] <- data.frame(
-        "label"  = if (estimatedMarginalMeansTermsTestsLeft) paste0(estimatedMarginalMeansVariables[i], ": ", tempTestText) else estimatedMarginalMeansVariables[i],
-        "row"    = tempRow,
-        "est"    = NA,
-        "lCi"    = NA,
-        "uCi"    = NA,
-        "test"   = if (estimatedMarginalMeansTermsTestsRight) tempTestText else "",
-        "face"   = NA
-      )
-      tempRow <- tempRow + 1
-
-      # add levels information
-      for (j in 1:nrow(tempEstimatedMarginalMeans)) {
-
-        tempCoefficientTest <- .maPrintCoefficientTest(tempEstimatedMarginalMeans[j,], estimatedMarginalMeansTestsStaistics)
-
-        additionalInformation[[tempRow]] <- data.frame(
-          "label"  = if (estimatedMarginalMeansCoefficientTestsLeft) paste0(tempEstimatedMarginalMeans$value[j], ": ", tempCoefficientTest) else tempEstimatedMarginalMeans$value[j],
-          "row"    = tempRow,
-          "est"    = tempEstimatedMarginalMeans$est[j],
-          "lCi"    = tempEstimatedMarginalMeans$lCi[j],
-          "uCi"    = tempEstimatedMarginalMeans$uCi[j],
-          "test"   = if (estimatedMarginalMeansCoefficientTestsRight) tempCoefficientTest else "",
-          "face"   = "italic"
-        )
-        additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans[j,], .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
-        additionalObjects[[tempRow]]$mapColor <- if(options[["forestPlotMappingColor"]] == estimatedMarginalMeansVariables[i]) tempEstimatedMarginalMeans$value[j] else NA
-        tempRow <- tempRow + 1
-
-
-        if (options[["forestPlotPredictionIntervals"]] || estimatedMarginalMeansCoefficientTestsBelow) {
-
-          additionalInformation[[tempRow]] <- data.frame(
-            "label"  = if (estimatedMarginalMeansCoefficientTestsBelow) tempCoefficientTest else NA,
-            "row"    = tempRow,
-            "est"    = NA,
-            "lCi"    = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$lPi[j] else NA,
-            "uCi"    = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$uPi[j] else NA,
-            "test"   = "",
-            "face"   = NA
-          )
-          if (options[["forestPlotPredictionIntervals"]]) {
-            additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans[j,], .maMakeRectangleDataFrame(lCi = lPi, uCi = uPi, row = tempRow, id = tempRow))
-            additionalObjects[[tempRow]]$mapColor <- if(options[["forestPlotMappingColor"]] == estimatedMarginalMeansVariables[i]) tempEstimatedMarginalMeans$value[j] else NA
-          }
-
-
-          tempRow <- tempRow + 1
+        # add space for forest header if specified
+        if (.forestPlotHasStudyInformationHeader(options)) {
+          forestHeaderIndex <- c(forestHeaderIndex, tempRow)
+          tempRow           <- tempRow + 1
         }
+
+        tempForestInformation   <- forestInput[[i]][["forest"]]
+        tempForestInformation$y <- tempForestInformation$y + (tempRow - 1)
+        forestInformation[[length(forestInformation) + 1]]  <- tempForestInformation
+
+        if (!is.null(forestInput[[i]][["prediction"]])) {
+          tempForestObjects    <- forestInput[[i]][["prediction"]]
+          tempForestObjects$y  <- tempForestInformation$y + (tempRow - 1)
+          tempForestObjects$id <- paste(tempForestObjects$id, i, sep = "_")
+          forestObjects[[length(forestObjects) + 1]]   <- tempForestObjects
+        }
+
+        tempRow <- tempRow + nrow(tempForestInformation) + 1
       }
 
-      # add empty row
-      tempRow <- tempRow + 1
+      # extract estimated marginal means input
+      if (doEstimatedMarginalMeans && length(estimatedMarginalMeansInput) > 0){
+
+        tempAdditionalInformation   <- estimatedMarginalMeansInput[[i]][["information"]]
+        tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
+        additionalInformation[[length(additionalInformation) + 1]]  <- tempAdditionalInformation
+
+        if (!is.null(estimatedMarginalMeansInput[[i]][["objects"]])) {
+          tempAdditionalObjects    <- estimatedMarginalMeansInput[[i]][["objects"]]
+          tempAdditionalObjects$y  <- tempAdditionalObjects$y + (tempRow - 1)
+          tempAdditionalObjects$id <- paste(tempAdditionalObjects$id, "emm", i, sep = "_")
+          additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
+        }
+
+        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+      }
+
+      # extract model information input
+      if (doModelInformation && length(modelInformationInput) > 0) {
+
+        tempAdditionalInformation   <- modelInformationInput[[i]][["information"]]
+        tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
+        additionalInformation[[length(additionalInformation) + 1]]  <- tempAdditionalInformation
+
+        if (!is.null(modelInformationInput[[i]][["objects"]])) {
+          tempAdditionalObjects    <- modelInformationInput[[i]][["objects"]]
+          tempAdditionalObjects$y  <- tempAdditionalObjects$y + (tempRow - 1)
+          tempAdditionalObjects$id <- paste(tempAdditionalObjects$id, "mi", i, sep = "_")
+          additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
+        }
+
+        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+      }
     }
+  } else {
 
-    # add adjusted effect size estimate
-    if (options[["forestPlotEstimatedMarginalMeansAdjustedEffectSizeEstimate"]]) {
+    # extract forest input
+    if (length(forestInput) > 0) {
 
-      tempEstimatedMarginalMeans <- .maComputeMarginalMeansVariable(fit, options, dataset, "", options[["forestPlotEstimatedMarginalMeansCoefficientTestsAgainst"]] , "effectSize")
-      tempCoefficientTest <- .maPrintCoefficientTest(tempEstimatedMarginalMeans, options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue")
+      for (i in seq_along(fit)) {
 
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = if (estimatedMarginalMeansCoefficientTestsLeft) paste0(gettext("Adjusted Estimate"), ": ", tempCoefficientTest) else gettext("Adjusted Estimate"),
-        "row"   = tempRow,
-        "est"   = tempEstimatedMarginalMeans$est,
-        "lCi"   = tempEstimatedMarginalMeans$lCi,
-        "uCi"   = tempEstimatedMarginalMeans$uCi,
-        "test"  = if (estimatedMarginalMeansCoefficientTestsRight) tempCoefficientTest else "",
-        "face"  = NA
-      )
-      additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans, .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
-      tempRow <- tempRow + 1
+        # add space for forest header if specified
+        if (.forestPlotHasStudyInformationHeader(options)) {
+          forestHeaderIndex <- c(forestHeaderIndex, tempRow)
+          tempRow           <- tempRow + 1
+        }
 
-      if (options[["forestPlotPredictionIntervals"]] || estimatedMarginalMeansCoefficientTestsBelow) {
+        # skip individual sections in case a subgroup analysis is performed and we are at the full fit object
+        # (which is in the end of the order)
+        if (i == length(fit) && options[["subgroup"]] != "")
+          next
 
-        additionalInformation[[tempRow]] <- data.frame(
-          "label" = if(estimatedMarginalMeansCoefficientTestsBelow) tempCoefficientTest else NA,
-          "row"   = tempRow,
-          "est"   = NA,
-          "lCi"   = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$lPi else NA,
-          "uCi"   = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$uPi else NA,
-          "test"  = "",
-          "face"  = NA
-        )
+        tempForestInformation   <- forestInput[[i]][["forest"]]
+        tempForestInformation$y <- tempForestInformation$y + (tempRow - 1)
+        forestInformation[[length(forestInformation) + 1]]  <- tempForestInformation
 
-        if (options[["forestPlotPredictionIntervals"]])
-          additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans, .maMakeRectangleDataFrame(lCi = lPi, uCi = uPi, row = tempRow, id = tempRow))
+        if (!is.null(forestInput[[i]][["prediction"]])) {
+          tempForestObjects    <- forestInput[[i]][["prediction"]]
+          tempForestObjects$y  <- tempForestInformation$y + (tempRow - 1)
+          tempForestObjects$id <- paste(tempForestObjects$id, i, sep = "_")
+          forestObjects[[length(forestObjects) + 1]]   <- tempForestObjects
+        }
 
-        tempRow <- tempRow + 1
+        tempRow <- tempRow + nrow(tempForestInformation) + 1
       }
     }
 
-    tempRow <- tempRow + 1
+    # extract estimated marginal means input
+    if (length(estimatedMarginalMeansInput) > 0){
+
+      for (i in seq_along(fit)) {
+
+        # skip individual sections in case a subgroup analysis is performed and we are at the full fit object
+        if (i == length(fit) && options[["subgroup"]] != "" && !options[["forestPlotSubgroupFullDatasetEstimatedMarginalMeans"]])
+          next
+
+        tempAdditionalInformation   <- estimatedMarginalMeansInput[[i]][["information"]]
+        tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
+        additionalInformation[[length(additionalInformation) + 1]]  <- tempAdditionalInformation
+
+        if (!is.null(estimatedMarginalMeansInput[[i]][["objects"]])) {
+          tempAdditionalObjects    <- estimatedMarginalMeansInput[[i]][["objects"]]
+          tempAdditionalObjects$y  <- tempAdditionalObjects$y + (tempRow - 1)
+          tempAdditionalObjects$id <- paste(tempAdditionalObjects$id, "emm", i, sep = "_")
+          additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
+        }
+
+        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+      }
+    }
+
+    # extract model information input
+    if (length(modelInformationInput) > 0) {
+
+      for (i in seq_along(fit)) {
+
+        # skip individual sections in case a subgroup analysis is performed and we are at the full fit object
+        if (i == length(fit) && options[["subgroup"]] != "" && !options[["forestPlotSubgroupFullDatasetModelInformation"]])
+          next
+
+        tempAdditionalInformation   <- modelInformationInput[[i]][["information"]]
+        tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
+        additionalInformation[[length(additionalInformation) + 1]]  <- tempAdditionalInformation
+
+        if (!is.null(modelInformationInput[[i]][["objects"]])) {
+          tempAdditionalObjects    <- modelInformationInput[[i]][["objects"]]
+          tempAdditionalObjects$y  <- tempAdditionalObjects$y + (tempRow - 1)
+          tempAdditionalObjects$id <- paste(tempAdditionalObjects$id, "mi", i, sep = "_")
+          additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
+        }
+
+        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+      }
+    }
   }
 
-
-  ### Model information panel ----
-
-  if (options[["forestPlotModelInformation"]]) {
-
-    if (any(unlist(options[c(
-      "forestPlotEffectSizeFixedEffectEstimate",
-      "forestPlotEffectSizeFixedEffectTest",
-      "forestPlotEffectSizePooledEstimate",
-      "forestPlotEffectSizePooledEstimateTest",
-      "forestPlotEffectSizeModerationTest",
-      "forestPlotHeterogeneityTest",
-      "forestPlotHeterogeneityEstimateTau",
-      "forestPlotHeterogeneityEstimateTau2",
-      "forestPlotHeterogeneityEstimateI2",
-      "forestPlotHeterogeneityEstimateH2",
-      "forestPlotHeterogeneityModerationTest"
-    )]))) {
-      # add Header
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = gettext("Model Information"),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = "bold"
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (options[["forestPlotResidualHeterogeneityTest"]]) {
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = .maPrintQTest(fit),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = NA
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (!.maGetMethodOptions(options) %in% c("FE", "EE") && options[["forestPlotHeterogeneityEstimateTau"]]) {
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "tau"),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = NA
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (!.maGetMethodOptions(options) %in% c("FE", "EE") && options[["forestPlotHeterogeneityEstimateTau2"]]) {
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "tau2"),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = NA
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (!.maGetMethodOptions(options) %in% c("FE", "EE") && !.maIsMetaregressionHeterogeneity(options) && options[["forestPlotHeterogeneityEstimateI2"]]) {
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "I2"),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = NA
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (!.maGetMethodOptions(options) %in% c("FE", "EE") && !.maIsMetaregressionHeterogeneity(options) && options[["forestPlotHeterogeneityEstimateH2"]]) {
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "H2"),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = NA
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (.maIsMetaregressionEffectSize(options) && options[["forestPlotEffectSizeModerationTest"]]) {
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = .maPrintModerationTest(fit, options, par = "effectSize"),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = NA
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (.maIsMetaregressionHeterogeneity(options) && options[["forestPlotHeterogeneityModerationTest"]]) {
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = .maPrintModerationTest(fit, options, par = "heterogeneity"),
-        "row"   = tempRow,
-        "est"   = NA,
-        "lCi"   = NA,
-        "uCi"   = NA,
-        "test"  = "",
-        "face"  = NA
-      )
-      tempRow <- tempRow + 1
-    }
-
-    if (options[["forestPlotEffectSizeFixedEffectEstimate"]]) {
-
-      pooledEffectSizeTestsRight <- options[["forestPlotEffectSizeFixedEffectTest"]] && options[["forestPlotTestsInRightPanel"]]
-      pooledEffectSizeTestsBelow <- options[["forestPlotEffectSizeFixedEffectTest"]] && !options[["forestPlotTestsInRightPanel"]] && options[["forestPlotPredictionIntervals"]]
-      pooledEffectSizeTestsLeft  <- options[["forestPlotEffectSizeFixedEffectTest"]] && !options[["forestPlotTestsInRightPanel"]] && !options[["forestPlotPredictionIntervals"]]
-
-      tempPooledEstimate <- .maComputePooledEffectPlot(fit, options, forceFixed = TRUE)
-      tempTestText       <- .maPrintCoefficientTest(tempPooledEstimate, options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue")
-
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = if (pooledEffectSizeTestsLeft) paste0(gettext("Fixed Effect Estimate"), ": ", tempTestText) else gettext("Fixed Effect Estimate"),
-        "row"   = tempRow,
-        "est"   = tempPooledEstimate$est,
-        "lCi"   = tempPooledEstimate$lCi,
-        "uCi"   = tempPooledEstimate$uCi,
-        "test"  = if (pooledEffectSizeTestsRight) tempTestText else "",
-        "face"  = NA
-      )
-      additionalObjects[[tempRow]] <- with(tempPooledEstimate, .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
-      tempRow <- tempRow + 1
-
-      if (pooledEffectSizeTestsBelow) {
-        additionalInformation[[tempRow]] <- data.frame(
-          "label" = if (pooledEffectSizeTestsBelow) tempTestText else NA,
-          "row"   = tempRow,
-          "est"   = NA,
-          "lCi"   = NA,
-          "uCi"   = NA,
-          "test"  = "",
-          "face"  = NA
-        )
-
-        tempRow <- tempRow + 1
-      }
-    }
-
-    if (options[["forestPlotEffectSizePooledEstimate"]]) {
-
-      pooledEffectSizeTestsRight <- options[["forestPlotEffectSizePooledEstimateTest"]] && options[["forestPlotTestsInRightPanel"]]
-      pooledEffectSizeTestsBelow <- options[["forestPlotEffectSizePooledEstimateTest"]] && !options[["forestPlotTestsInRightPanel"]] && options[["forestPlotPredictionIntervals"]]
-      pooledEffectSizeTestsLeft  <- options[["forestPlotEffectSizePooledEstimateTest"]] && !options[["forestPlotTestsInRightPanel"]] && !options[["forestPlotPredictionIntervals"]]
-
-      tempPooledEstimate <- .maComputePooledEffectPlot(fit, options)
-      tempTestText      <- .maPrintCoefficientTest(tempPooledEstimate, options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue")
-
-      additionalInformation[[tempRow]] <- data.frame(
-        "label" = if (pooledEffectSizeTestsLeft) paste0(gettext("Pooled Estimate"), ": ", tempTestText) else gettext("Pooled Estimate"),
-        "row"   = tempRow,
-        "est"   = tempPooledEstimate$est,
-        "lCi"   = tempPooledEstimate$lCi,
-        "uCi"   = tempPooledEstimate$uCi,
-        "test"  = if (pooledEffectSizeTestsRight) tempTestText else "",
-        "face"  = NA
-      )
-      additionalObjects[[tempRow]] <- with(tempPooledEstimate, .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
-      tempRow <- tempRow + 1
-
-      if (pooledEffectSizeTestsBelow || options[["forestPlotPredictionIntervals"]]) {
-        additionalInformation[[tempRow]] <- data.frame(
-          "label" = if (pooledEffectSizeTestsBelow) tempTestText else NA,
-          "row"   = tempRow,
-          "est"   = NA,
-          "lCi"   = if (options[["forestPlotPredictionIntervals"]]) tempPooledEstimate$lPi else NA,
-          "uCi"   = if (options[["forestPlotPredictionIntervals"]]) tempPooledEstimate$uPi else NA,
-          "test"  = "",
-          "face"  = NA
-        )
-
-        if (options[["forestPlotPredictionIntervals"]])
-          additionalObjects[[tempRow]] <- with(tempPooledEstimate, .maMakeRectangleDataFrame(lCi = lPi, uCi = uPi, row = tempRow, id = tempRow))
-
-        tempRow <- tempRow + 1
-      }
-    }
-
-  }
-
-
-  ### Merge results from estimated marginal means and information panel ----
-  if (length(additionalInformation) > 0) {
-
-    # merge additional information
-    additionalInformation <- do.call(rbind, additionalInformation)
+  ### adjust the inputs ----
+  # merge the parts
+  if (!is.null(forestInformation))
+    forestInformation     <- do.call(rbind, forestInformation[!sapply(forestInformation, is.null)])
+  if (!is.null(forestObjects))
+    forestObjects         <- do.call(rbind, forestObjects[!sapply(forestObjects, is.null)])
+  if (!is.null(additionalInformation))
+    additionalInformation <- do.call(rbind, additionalInformation[!sapply(additionalInformation, is.null)])
+  if (!is.null(additionalObjects))
     additionalObjects     <- do.call(rbind, additionalObjects[!sapply(additionalObjects, is.null)])
 
-    # adjust y-coordinates
-    additionalInformation$y <- -additionalInformation$row * relativeRowSize
-    additionalObjects$y     <- -additionalObjects$y * relativeRowSize
+  # adjust y-coordinates
+  if (!is.null(forestHeaderIndex))
+    forestHeaderIndex       <- - forestHeaderIndex       * options[["forestPlotRelativeSizeRow"]]
+  if (!is.null(forestInformation))
+    forestInformation$y     <- - forestInformation$y     * options[["forestPlotRelativeSizeRow"]]
+  if (!is.null(forestObjects))
+    forestObjects$y         <- - forestObjects$y         * options[["forestPlotRelativeSizeRow"]]
+  if (!is.null(additionalInformation))
+    additionalInformation$y <- - additionalInformation$y * options[["forestPlotRelativeSizeRow"]]
+  if (!is.null(additionalObjects))
+    additionalObjects$y     <- - additionalObjects$y     * options[["forestPlotRelativeSizeRow"]]
 
-    xRangeAddedPanels <- range(c(additionalInformation$lCi, additionalInformation$uCi, additionalObjects$x), na.rm = TRUE)
-  } else {
-    xRangeAddedPanels <- NA
-  }
 
-  # specify x-axis limits
-  if (options[["forestPlotAuxiliarySetXAxisLimit"]]) {
-    xBreaks <- jaspGraphs::getPrettyAxisBreaks(c(options[["forestPlotAuxiliarySetXAxisLimitLower"]], options[["forestPlotAuxiliarySetXAxisLimitUpper"]]))
-  } else {
-    xBreaks <- jaspGraphs::getPrettyAxisBreaks(range(c(xRangeStudyInformationPanel, xRangeAddedPanels), na.rm = TRUE))
-  }
-  xRange <- range(xBreaks)
-
-  # specify y-axis limits
-  if (options[["forestPlotStudyInformation"]]) {
-    yRange <- c(0, max(dfForrest$y) + relativeRowSize + any(leftPanelStudyInformation$title != ""))
-  } else {
-    yRange <- c(0, 0)
-  }
-  if (length(additionalInformation) > 0) {
-    yRange[1] <- min(additionalInformation$y) - relativeRowSize
-  }
-  if (length(additionalInformation) > 0) {
-    yRange[1] <- min(c(additionalObjects$y, yRange))
-  }
-
-  ### Make the forest plot ----
+  ### make the forest plot ----
   plotForest <- ggplot2::ggplot()
 
   # study information panel estimates
@@ -507,7 +240,7 @@
         fill  = if (options[["forestPlotMappingColor"]] != "") as.name(options[["forestPlotMappingColor"]])
       )
       geomCall <- list(
-        data    = fitPrediction,
+        data    = forestObjects,
         mapping = do.call(ggplot2::aes, aesCall[!sapply(aesCall, is.null)]),
         fill    = if (options[["forestPlotMappingColor"]] == "") "grey20",
         alpha   = 0.8
@@ -525,7 +258,7 @@
       size  = as.name("weights")
     )
     geomCall <- list(
-      data    = dfForrest,
+      data    = forestInformation,
       mapping = do.call(ggplot2::aes, aesCall[!sapply(aesCall, is.null)]),
       color   = if (options[["forestPlotMappingColor"]] == "") options[["forestPlotAuxiliaryPlotColor"]],
       shape   = if (options[["forestPlotMappingShape"]] == "") 15
@@ -536,12 +269,12 @@
 
     # change scale for shapes to full shapes if used
     if (options[["forestPlotMappingShape"]] != "")
-      plotForest <- plotForest + ggplot2::scale_shape_manual(values = rep(c(15:18, 21:25), length.out = length(unique(dfForrest[[options[["forestPlotMappingShape"]]]]))))
+      plotForest <- plotForest + ggplot2::scale_shape_manual(values = rep(c(15:18, 21:25), length.out = length(unique(forestInformation[[options[["forestPlotMappingShape"]]]]))))
 
 
     ### add CIs
     plotForest <- plotForest + ggplot2::geom_errorbarh(
-      data    = dfForrest,
+      data    = forestInformation,
       mapping = ggplot2::aes(
         xmin = lCi,
         xmax = uCi,
@@ -552,7 +285,7 @@
 
     if (options[["forestPlotStudyInformationSecondaryConfidenceInterval"]]) {
       plotForest <- plotForest + ggplot2::geom_errorbarh(
-        data    = dfForrest,
+        data    = forestInformation,
         mapping = ggplot2::aes(
           xmin = lCi2,
           xmax = uCi2,
@@ -600,76 +333,51 @@
     plotForest <- plotForest + ggplot2::geom_vline(xintercept = options[["forestPlotAuxiliaryAddVerticalLineValue2"]], linetype = "dotted")
 
 
-  ### Make the left information panel ----
-  if (length(options[["forestPlotStudyInformationSelectedVariablesSettings"]]) > 0 || length(additionalInformation) > 0) {
+  ### make the left information panel ----
+  if ((options[["forestPlotStudyInformation"]] && length(options[["forestPlotStudyInformationSelectedVariablesSettings"]]) > 0) || length(additionalInformation) > 0) {
 
-    ### determine number of columns and study information
-    leftPanelStudyInformation   <- do.call(rbind.data.frame, options[["forestPlotStudyInformationSelectedVariablesSettings"]])
+    plotLeft     <- ggplot2::ggplot()
+    maxCharsLeft <- NULL
 
-    ### compute the total character width
-    if (options[["forestPlotStudyInformation"]] && length(leftPanelStudyInformation) != 0) {
-      leftPanelStudyInformationChars <- rbind(
-        nchar(leftPanelStudyInformation$title),
-        apply(dfForrest[,leftPanelStudyInformation$value, drop = FALSE], 2, function(x) max(nchar(x), na.rm = TRUE)))
-      leftPanelStudyInformationChars <- apply(leftPanelStudyInformationChars, 2, max) + 2
-      maxCharsLeft <- sum(leftPanelStudyInformationChars)
-    } else {
-      leftPanelStudyInformationChars <- 0
-      maxCharsLeft <- 0
-    }
-    if (length(additionalInformation) != 0) {
-      additionalInformationChars <- max(nchar(additionalInformation$label), na.rm = TRUE)
-      maxCharsLeft <- max(c(maxCharsLeft, additionalInformationChars))
-    } else {
-      additionalInformationChars <- 0
-    }
+    # add forest information
+    if (options[["forestPlotStudyInformation"]] && length(options[["forestPlotStudyInformationSelectedVariablesSettings"]]) > 0) {
 
-    ### start plotting
-    plotLeft <- ggplot2::ggplot()
-
-    ### add the subplots
-    if (options[["forestPlotStudyInformation"]] && length(leftPanelStudyInformation) > 0) {
-
-      # split the columns
-      if (options[["forestPlotAuxiliaryAdjustWidthBasedOnText"]]) {
-        leftPanelRelativeWidths <- c(maxCharsLeft - sum(leftPanelStudyInformationChars), leftPanelStudyInformationChars)
-        leftPanelRelativeWidths[2:length(leftPanelRelativeWidths)] <- leftPanelRelativeWidths[2:length(leftPanelRelativeWidths)] * leftPanelStudyInformation$width
-        leftPanelRelativeWidths <- leftPanelRelativeWidths / sum(leftPanelRelativeWidths)
-        leftPanelStudyInformation$xStart    <- cumsum(leftPanelRelativeWidths[-length(leftPanelRelativeWidths)])
-        leftPanelStudyInformation$xEnd      <- cumsum(leftPanelRelativeWidths)[-1]
-      } else {
-        leftPanelRelativeWidths <- leftPanelStudyInformation$width / sum(leftPanelStudyInformation$width)
-        leftPanelStudyInformation$xStart <- c(0, cumsum(leftPanelRelativeWidths[-length(leftPanelRelativeWidths)]))
-        leftPanelStudyInformation$xEnd   <- cumsum(leftPanelRelativeWidths)
-      }
+      # build the study information header
+      leftPanelStudyInformation <- .forestPlotBuildStudyInformationHeader(options, forestInformation, additionalInformation)
+      maxCharsLeft              <- attr(leftPanelStudyInformation, "maxChars")
 
       # compute study information coordinates
-      leftPanelStudyInformation$y         <- (max(dfForrest$row) + 1) * relativeRowSize
-      leftPanelStudyInformation$x         <- ifelse(
+      leftPanelStudyInformation$x <- ifelse(
         leftPanelStudyInformation$alignment == "left", leftPanelStudyInformation$xStart, ifelse(
           leftPanelStudyInformation$alignment == "middle", (leftPanelStudyInformation$xStart + leftPanelStudyInformation$xEnd) / 2, leftPanelStudyInformation$xEnd
-      ))
+        ))
+      leftPanelStudyInformation <- do.call(rbind, lapply(forestHeaderIndex, function(y) {
+        leftPanelStudyInformation$y <- y
+        return(leftPanelStudyInformation)
+      }))
 
       # add titles
-      plotLeft <- plotLeft + ggplot2::geom_text(
-        data    = leftPanelStudyInformation,
-        mapping = ggplot2::aes(
-          x     = x,
-          y     = y,
-          label = title,
-          hjust = alignment
-        ),
-        size     = 4 * options[["forestPlotRelativeSizeText"]],
-        vjust    = "midle",
-        fontface = "bold"
-      )
+      if (length(leftPanelStudyInformation) > 0) {
+        plotLeft <- plotLeft + ggplot2::geom_text(
+          data    = leftPanelStudyInformation,
+          mapping = ggplot2::aes(
+            x     = x,
+            y     = y,
+            label = title,
+            hjust = alignment
+          ),
+          size     = 4 * options[["forestPlotRelativeSizeText"]],
+          vjust    = "midle",
+          fontface = "bold"
+        )
+      }
 
       # add information
       if (any(leftPanelStudyInformation$value == options[["forestPlotMappingColor"]])) {
         leftPanelStudyDataColored <- data.frame(
           x         = leftPanelStudyInformation$x[leftPanelStudyInformation$value == options[["forestPlotMappingColor"]]],
-          y         = dfForrest$y,
-          label     = as.character(dfForrest[[options[["forestPlotMappingColor"]]]]),
+          y         = forestInformation$y,
+          label     = as.character(forestInformation[[options[["forestPlotMappingColor"]]]]),
           alignment = leftPanelStudyInformation$alignment[leftPanelStudyInformation$value == options[["forestPlotMappingColor"]]]
         )
         plotLeft <- plotLeft + ggplot2::geom_text(
@@ -686,12 +394,12 @@
         )
       }
       if (any(leftPanelStudyInformation$value != options[["forestPlotMappingColor"]])) {
-        tempVariables <- leftPanelStudyInformation$value[leftPanelStudyInformation$value != options[["forestPlotMappingColor"]]]
+        tempVariables <- unique(leftPanelStudyInformation$value[leftPanelStudyInformation$value != options[["forestPlotMappingColor"]]])
         leftPanelStudyData <- do.call(rbind.data.frame, lapply(tempVariables, function(variable) {
           data.frame(
             x         = leftPanelStudyInformation$x[leftPanelStudyInformation$value == variable],
-            y         = dfForrest$y,
-            label     = as.character(dfForrest[[variable]]),
+            y         = forestInformation$y,
+            label     = as.character(forestInformation[[variable]]),
             alignment = leftPanelStudyInformation$alignment[leftPanelStudyInformation$value == variable]
           )
         }))
@@ -707,15 +415,16 @@
           vjust    = "midle",
         )
       }
-
     }
 
+    # add additional information
     if (length(additionalInformation) > 0) {
 
       # subset left panel information only
       leftPanelAdditionalInformation   <- additionalInformation[!is.na(additionalInformation$label),]
       leftPanelAdditionalInformation$x <- 1
       leftPanelAdditionalInformation$face[is.na(leftPanelAdditionalInformation$face)] <- "plain"
+      maxCharsLeft <- max(c(maxCharsLeft, max(nchar(leftPanelAdditionalInformation$label))), na.rm = TRUE)
 
       # add titles
       plotLeft <- plotLeft + ggplot2::geom_text(
@@ -731,19 +440,21 @@
         vjust    = "midle",
       )
     }
+
   } else {
     plotLeft <- NULL
   }
-  ### Make the right information panel ----
-  if (.maForestPlotMakeRightPannel(options, additionalInformation)) {
 
-    # estimates and confidence intervales
+  ### make the right information panel ----
+  if (.forestPlotHasrightPanel(options, additionalInformation)) {
+
+    # estimates and confidence intervals
     if (options[["forestPlotEstimatesAndConfidenceIntervals"]]) {
 
       ### join the est and Cis for the right panel
       rightPanelCis <- rbind(
         if (options[["forestPlotStudyInformation"]]) {
-          tempDf <- dfForrest[,c("y", "effectSize", "lCi", "uCi")]
+          tempDf <- forestInformation[,c("y", "effectSize", "lCi", "uCi")]
           colnames(tempDf) <- c("y", "est", "lCi", "uCi")
           tempDf
         },
@@ -772,7 +483,7 @@
     ### tests and weights right panel
     rightPanelTestsAndWeights <- rbind(
       if (options[["forestPlotStudyInformation"]] > 0 && options[["forestPlotStudyInformationStudyWeights"]]) {
-        tempDf <- dfForrest[,c("y", "weights")]
+        tempDf <- forestInformation[,c("y", "weights")]
         tempDf$label <- paste0(sprintf(paste0("%1$.", options[["forestPlotAuxiliaryDigits"]], "f"), tempDf$weights), " %")
         tempDf[,c("y", "label")]
       },
@@ -844,6 +555,25 @@
   }
 
   ### adjust axis, themes, and labels ----
+
+  # specify axis limits & breaks
+  if (options[["forestPlotAuxiliarySetXAxisLimit"]]) {
+    xBreaks <- jaspGraphs::getPrettyAxisBreaks(c(options[["forestPlotAuxiliarySetXAxisLimitLower"]], options[["forestPlotAuxiliarySetXAxisLimitUpper"]]))
+  } else {
+    xBreaks <- jaspGraphs::getPrettyAxisBreaks(range(c(
+      forestInformation$lCi, forestInformation$uCi,
+      forestObjects$x,
+      additionalInformation$lCi, additionalInformation$uCi,
+      additionalObjects$x
+    ), na.rm = TRUE))
+  }
+  xRange <- range(xBreaks)
+
+  yRange <- c(
+    min(c(
+      forestInformation$y, forestObjects$y, additionalInformation$y, additionalObjects$y
+    ), na.rm = TRUE), 0)
+  yRange[1] <- yRange[1] - options[["forestPlotRelativeSizeRow"]]
 
   # fix plotting range
   plotForest <- plotForest + ggplot2::coord_cartesian(
@@ -934,7 +664,7 @@
 
     plotOut <- plotForest
     attr(plotOut, "isPanel") <- FALSE
-    attr(plotOut, "rows")    <- tempRow + max(dfForrest$row)
+    attr(plotOut, "rows")    <- tempRow + max(forestInformation$y)
 
   } else {
 
@@ -947,7 +677,7 @@
 
     attr(plotOut, "isPanel")     <- TRUE
     attr(plotOut, "panelRatio")  <- panelRatio
-    attr(plotOut, "rows")        <- tempRow + if(!is.null(dfForrest)) max(dfForrest$row) else 0
+    attr(plotOut, "rows")        <- tempRow + if(!is.null(forestInformation)) max(forestInformation$y) else 0
     attr(plotOut, "widths")      <- plotsWidths
     attr(plotOut, "layout")      <- matrix(1:length(plotOut), nrow = 1, ncol = length(plotOut), byrow = TRUE)
 
@@ -955,7 +685,545 @@
 
   return(plotOut)
 }
-.maForestPlotMakeRightPannel <- function(options, additionalInformation) {
+
+.forestPlotBuildStudyInformation       <- function(fit, options){
+
+  ### builds the study information section
+  # returns a
+  # - data frame with the study information
+  # - data frame with the predicted effects
+
+  # return null on error
+  if (is.null(fit) || jaspBase::isTryError(fit))
+    return(NULL)
+
+  # extract data set forwarded via the fit object
+  # allows dispatching from subfits, NAs removal matching the analysis etc
+  dataset <- attr(fit, "dataset")
+
+  ### extract effect sizes and variances from the fitted object
+  dfForest <- data.frame(
+    effectSize     = fit[["yi"]],
+    standardError  = sqrt(fit[["vi"]]),
+    weights        = weights(fit),
+    id             = seq_along(fit[["yi"]])
+  )
+
+  # add CI using normal approximation
+  dfForest$lCi <- dfForest$effectSize - qnorm((1 - options[["confidenceIntervalsLevel"]]) / 2, lower.tail = F) * dfForest$standardError
+  dfForest$uCi <- dfForest$effectSize + qnorm((1 - options[["confidenceIntervalsLevel"]]) / 2, lower.tail = F) * dfForest$standardError
+
+  # add secondary CI using normal approximation
+  if (options[["forestPlotStudyInformationSecondaryConfidenceInterval"]]) {
+    dfForest$lCi2 <- dfForest$effectSize - qnorm((1 - options[["forestPlotStudyInformationSecondaryConfidenceIntervalLevel"]]) / 2, lower.tail = F) * dfForest$standardError
+    dfForest$uCi2 <- dfForest$effectSize + qnorm((1 - options[["forestPlotStudyInformationSecondaryConfidenceIntervalLevel"]]) / 2, lower.tail = F) * dfForest$standardError
+  }
+
+  # transform effect size when requested
+  if (options[["transformEffectSize"]] != "none") {
+    dfForest[,c(
+      "effectSize", "lCi", "uCi",
+      if (options[["forestPlotStudyInformationSecondaryConfidenceInterval"]]) c("lCi2", "uCi2"))] <- do.call(
+        .maGetEffectSizeTransformationOptions(options[["transformEffectSize"]]),
+        list(dfForest[,c(
+          "effectSize", "lCi", "uCi",
+          if (options[["forestPlotStudyInformationSecondaryConfidenceInterval"]]) c("lCi2", "uCi2"))]))
+  }
+
+  # add variables used for either color, shape, order or Left panel information
+  additionalVariables <- c(
+    if (length(options[["forestPlotStudyInformationSelectedVariables"]]) > 0) unlist(options[["forestPlotStudyInformationSelectedVariables"]]),
+    if (options[["forestPlotStudyInformationOrderBy"]] != "")                 options[["forestPlotStudyInformationOrderBy"]],
+    if (options[["forestPlotMappingColor"]] != "")                            options[["forestPlotMappingColor"]],
+    if (options[["forestPlotMappingShape"]] != "")                            options[["forestPlotMappingShape"]]
+  )
+  if (length(additionalVariables) > 0)
+    dfForest <- cbind(dfForest, dataset[,additionalVariables,drop=FALSE])
+
+  # TODO: temporal fix for the variable names in the Component list not being properly translated
+  # for (i in seq_along(options[["forestPlotStudyInformationSelectedVariables"]])) {
+  #   options[["forestPlotStudyInformationSelectedVariablesSettings"]][[i]][["value"]] <- options[["forestPlotStudyInformationSelectedVariables"]][[i]]
+  # }
+
+  # re-order
+  if (options[["forestPlotStudyInformationOrderBy"]] != "") {
+    dfForest <- dfForest[order(
+      dfForest[,options[["forestPlotStudyInformationOrderBy"]]],
+      decreasing = options[["forestPlotStudyInformationOrderAscending"]]),]
+  }
+
+  # add y-axis coordinates for plotting
+  dfForest$y <- seq(nrow(dfForest))
+
+
+  ### add predicted effects
+  if (options[["forestPlotStudyInformationPredictedEffects"]]) {
+
+    dfForestPrediction <- data.frame(predict(fit))
+
+    # replicate the prediction for each estimate if the predictions are the same (no moderators)
+    if (nrow(dfForestPrediction) == 1)
+      dfForestPrediction <- do.call(rbind, replicate(nrow(dfForest), dfForestPrediction, simplify = FALSE))
+
+    dfForestPrediction$id <- dfForest$id
+    dfForestPrediction$y  <- dfForest$y
+
+    # create prediction diamond coordinates for each estimate
+    dfForestPrediction <- do.call(rbind, lapply(1:nrow(dfForestPrediction), function(i) {
+      with(dfForestPrediction[i,], .maMakeDiamondDataFrame(est = pred, lCi = pi.lb, uCi = pi.ub, row = y, id = id))
+    }))
+
+    dfForestPrediction <- merge(dfForestPrediction, dfForest[,!colnames(dfForest) %in% c("effectSize", "standardError", "weights", "lCi", "uCi", "y")], by = "id")
+
+    # transform effect size when requested
+    if (options[["transformEffectSize"]] != "none")
+      dfForestPrediction[,"xPrediction"] <- do.call(
+        .maGetEffectSizeTransformationOptions(options[["transformEffectSize"]]),
+        list(dfForestPrediction[,"xPrediction"]))
+
+  } else {
+    dfForestPrediction <- NULL
+  }
+
+  # return
+  return(list(
+    forest     = dfForest,
+    prediction = dfForestPrediction
+  ))
+}
+.forestPlotBuildEstimatedMarginalMeans <- function(fit, options){
+
+  ### builds the estimated marginal means section
+  # returns a
+  # - data frame with the estimated marginal means information
+  # - a list with the estimated marginal means prediction intervals
+
+  # return null on error
+  if (is.null(fit) || jaspBase::isTryError(fit))
+    return(NULL)
+
+  dataset <- attr(fit, "dataset")
+
+  # Make sure no multiple prediction intervals are drawn for complex models
+  if (.mammHasMultipleHeterogeneities(options)) {
+    options[["predictionIntervals"]]           <- FALSE
+    options[["forestPlotPredictionIntervals"]] <- FALSE
+  }
+
+  # initiate the local objects
+  tempRow <- 1
+  additionalInformation <- list()
+  additionalObjects     <- list()
+
+  # terms and levels information
+  estimatedMarginalMeansTestsStaistics   <- options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue"
+  estimatedMarginalMeansVariables        <- unlist(options[["forestPlotEstimatedMarginalMeansSelectedVariables"]])
+
+  # statistics position adjustment
+  estimatedMarginalMeansTermsTestsRight  <- options[["forestPlotEstimatedMarginalMeansTermTests"]] && options[["forestPlotTestsInRightPanel"]]
+  estimatedMarginalMeansTermsTestsLeft   <- options[["forestPlotEstimatedMarginalMeansTermTests"]] && !options[["forestPlotTestsInRightPanel"]]
+
+  estimatedMarginalMeansCoefficientTestsRight <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && options[["forestPlotTestsInRightPanel"]]
+  estimatedMarginalMeansCoefficientTestsBelow <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && !options[["forestPlotTestsInRightPanel"]] && options[["forestPlotPredictionIntervals"]]
+  estimatedMarginalMeansCoefficientTestsLeft  <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && !options[["forestPlotTestsInRightPanel"]] && !options[["forestPlotPredictionIntervals"]]
+
+  # add header
+  additionalInformation[[tempRow]] <- data.frame(
+    "label"  = gettextf(
+      "Estimated Marginal Means%1$s",
+      if (options[["subgroup"]] != "") gettextf(" (Subgroup: %1$s)", attr(fit, "subgroup")) else ""
+    ),
+    "y"      = tempRow,
+    "est"    = NA,
+    "lCi"    = NA,
+    "uCi"    = NA,
+    "test"   = "",
+    "face"   = "bold"
+  )
+  tempRow <- tempRow + 1
+
+  # add marginal estimates
+  for (i in seq_along(estimatedMarginalMeansVariables)) {
+
+    tempTermTest               <- .maTermTests(fit, options, estimatedMarginalMeansVariables[i])
+    tempEstimatedMarginalMeans <- .maComputeMarginalMeansVariable(fit, options, dataset, estimatedMarginalMeansVariables[i], options[["forestPlotEstimatedMarginalMeansCoefficientTestsAgainst"]] , "effectSize")
+    tempTestText               <- .maPrintTermTest(tempTermTest, estimatedMarginalMeansTestsStaistics)
+
+    # add term information
+    additionalInformation[[tempRow]] <- data.frame(
+      "label"  = if (estimatedMarginalMeansTermsTestsLeft) paste0(estimatedMarginalMeansVariables[i], ": ", tempTestText) else estimatedMarginalMeansVariables[i],
+      "y"      = tempRow,
+      "est"    = NA,
+      "lCi"    = NA,
+      "uCi"    = NA,
+      "test"   = if (estimatedMarginalMeansTermsTestsRight) tempTestText else "",
+      "face"   = NA
+    )
+    tempRow <- tempRow + 1
+
+    # add levels information
+    for (j in 1:nrow(tempEstimatedMarginalMeans)) {
+
+      tempCoefficientTest <- .maPrintCoefficientTest(tempEstimatedMarginalMeans[j,], estimatedMarginalMeansTestsStaistics)
+
+      additionalInformation[[tempRow]] <- data.frame(
+        "label"  = if (estimatedMarginalMeansCoefficientTestsLeft) paste0(tempEstimatedMarginalMeans$value[j], ": ", tempCoefficientTest) else tempEstimatedMarginalMeans$value[j],
+        "y"      = tempRow,
+        "est"    = tempEstimatedMarginalMeans$est[j],
+        "lCi"    = tempEstimatedMarginalMeans$lCi[j],
+        "uCi"    = tempEstimatedMarginalMeans$uCi[j],
+        "test"   = if (estimatedMarginalMeansCoefficientTestsRight) tempCoefficientTest else "",
+        "face"   = "italic"
+      )
+      additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans[j,], .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
+      additionalObjects[[tempRow]]$mapColor <- if(options[["forestPlotMappingColor"]] == estimatedMarginalMeansVariables[i]) tempEstimatedMarginalMeans$value[j] else NA
+      tempRow <- tempRow + 1
+
+
+      if (options[["forestPlotPredictionIntervals"]] || estimatedMarginalMeansCoefficientTestsBelow) {
+
+        additionalInformation[[tempRow]] <- data.frame(
+          "label"  = if (estimatedMarginalMeansCoefficientTestsBelow) tempCoefficientTest else NA,
+          "y"      = tempRow,
+          "est"    = NA,
+          "lCi"    = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$lPi[j] else NA,
+          "uCi"    = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$uPi[j] else NA,
+          "test"   = "",
+          "face"   = NA
+        )
+        if (options[["forestPlotPredictionIntervals"]]) {
+          additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans[j,], .maMakeRectangleDataFrame(lCi = lPi, uCi = uPi, row = tempRow, id = tempRow))
+          additionalObjects[[tempRow]]$mapColor <- if(options[["forestPlotMappingColor"]] == estimatedMarginalMeansVariables[i]) tempEstimatedMarginalMeans$value[j] else NA
+        }
+
+
+        tempRow <- tempRow + 1
+      }
+    }
+
+    # add empty row
+    tempRow <- tempRow + 1
+  }
+
+  # add adjusted effect size estimate
+  if (options[["forestPlotEstimatedMarginalMeansAdjustedEffectSizeEstimate"]]) {
+
+    tempEstimatedMarginalMeans <- .maComputeMarginalMeansVariable(fit, options, dataset, "", options[["forestPlotEstimatedMarginalMeansCoefficientTestsAgainst"]] , "effectSize")
+    tempCoefficientTest <- .maPrintCoefficientTest(tempEstimatedMarginalMeans, options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue")
+
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = if (estimatedMarginalMeansCoefficientTestsLeft) paste0(gettext("Adjusted Estimate"), ": ", tempCoefficientTest) else gettext("Adjusted Estimate"),
+      "y"     = tempRow,
+      "est"   = tempEstimatedMarginalMeans$est,
+      "lCi"   = tempEstimatedMarginalMeans$lCi,
+      "uCi"   = tempEstimatedMarginalMeans$uCi,
+      "test"  = if (estimatedMarginalMeansCoefficientTestsRight) tempCoefficientTest else "",
+      "face"  = NA
+    )
+    additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans, .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
+    tempRow <- tempRow + 1
+
+    if (options[["forestPlotPredictionIntervals"]] || estimatedMarginalMeansCoefficientTestsBelow) {
+
+      additionalInformation[[tempRow]] <- data.frame(
+        "label" = if(estimatedMarginalMeansCoefficientTestsBelow) tempCoefficientTest else NA,
+        "y"     = tempRow,
+        "est"   = NA,
+        "lCi"   = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$lPi else NA,
+        "uCi"   = if (options[["forestPlotPredictionIntervals"]]) tempEstimatedMarginalMeans$uPi else NA,
+        "test"  = "",
+        "face"  = NA
+      )
+
+      if (options[["forestPlotPredictionIntervals"]])
+        additionalObjects[[tempRow]] <- with(tempEstimatedMarginalMeans, .maMakeRectangleDataFrame(lCi = lPi, uCi = uPi, row = tempRow, id = tempRow))
+
+      tempRow <- tempRow + 1
+    }
+  }
+
+  # return
+  return(list(
+    information = do.call(rbind, additionalInformation),
+    objects     = do.call(rbind,additionalObjects[!sapply(additionalObjects, is.null)])
+  ))
+}
+.forestPlotBuildModelInformation       <- function(fit, options){
+
+  ### builds the model information section
+  # returns a
+  # - data frame with the model information information
+  # - a list with the model information prediction intervals
+
+  # return null on error
+  if (is.null(fit) || jaspBase::isTryError(fit))
+    return(NULL)
+
+  # return null if no model information is requested
+  if (!any(unlist(options[c(
+    "forestPlotEffectSizeFixedEffectEstimate",
+    "forestPlotEffectSizeFixedEffectTest",
+    "forestPlotEffectSizePooledEstimate",
+    "forestPlotEffectSizePooledEstimateTest",
+    "forestPlotEffectSizeModerationTest",
+    "forestPlotHeterogeneityTest",
+    "forestPlotHeterogeneityEstimateTau",
+    "forestPlotHeterogeneityEstimateTau2",
+    "forestPlotHeterogeneityEstimateI2",
+    "forestPlotHeterogeneityEstimateH2",
+    "forestPlotHeterogeneityModerationTest"
+  )])))
+    return(NULL)
+
+  # Make sure no multiple prediction intervals are drawn for complex models
+  if (.mammHasMultipleHeterogeneities(options)) {
+    options[["predictionIntervals"]]           <- FALSE
+    options[["forestPlotPredictionIntervals"]] <- FALSE
+  }
+
+  # initiate the local objects
+  tempRow <- 1
+  additionalInformation <- list()
+  additionalObjects     <- list()
+
+  # add Header
+  additionalInformation[[tempRow]] <- data.frame(
+    "label"  = gettextf(
+      "Model Fit%1$s",
+      if (options[["subgroup"]] != "") gettextf(" (Subgroup: %1$s)", attr(fit, "subgroup")) else ""
+    ),
+    "y"     = tempRow,
+    "est"   = NA,
+    "lCi"   = NA,
+    "uCi"   = NA,
+    "test"  = "",
+    "face"  = "bold"
+  )
+  tempRow <- tempRow + 1
+
+  if (options[["forestPlotResidualHeterogeneityTest"]]) {
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = .maPrintQTest(fit),
+      "y"     = tempRow,
+      "est"   = NA,
+      "lCi"   = NA,
+      "uCi"   = NA,
+      "test"  = "",
+      "face"  = NA
+    )
+    tempRow <- tempRow + 1
+  }
+
+  if (!.maGetMethodOptions(options) %in% c("FE", "EE") && options[["forestPlotHeterogeneityEstimateTau"]]) {
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "tau"),
+      "y"     = tempRow,
+      "est"   = NA,
+      "lCi"   = NA,
+      "uCi"   = NA,
+      "test"  = "",
+      "face"  = NA
+    )
+    tempRow <- tempRow + 1
+  }
+
+  if (!.maGetMethodOptions(options) %in% c("FE", "EE") && options[["forestPlotHeterogeneityEstimateTau2"]]) {
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "tau2"),
+      "y"     = tempRow,
+      "est"   = NA,
+      "lCi"   = NA,
+      "uCi"   = NA,
+      "test"  = "",
+      "face"  = NA
+    )
+    tempRow <- tempRow + 1
+  }
+
+  if (!.maGetMethodOptions(options) %in% c("FE", "EE") && !.maIsMetaregressionHeterogeneity(options) && options[["forestPlotHeterogeneityEstimateI2"]]) {
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "I2"),
+      "y"     = tempRow,
+      "est"   = NA,
+      "lCi"   = NA,
+      "uCi"   = NA,
+      "test"  = "",
+      "face"  = NA
+    )
+    tempRow <- tempRow + 1
+  }
+
+  if (!.maGetMethodOptions(options) %in% c("FE", "EE") && !.maIsMetaregressionHeterogeneity(options) && options[["forestPlotHeterogeneityEstimateH2"]]) {
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = .maPrintHeterogeneityEstimate(fit, options, digits = options[["forestPlotAuxiliaryDigits"]], parameter = "H2"),
+      "y"     = tempRow,
+      "est"   = NA,
+      "lCi"   = NA,
+      "uCi"   = NA,
+      "test"  = "",
+      "face"  = NA
+    )
+    tempRow <- tempRow + 1
+  }
+
+  if (.maIsMetaregressionEffectSize(options) && options[["forestPlotEffectSizeModerationTest"]]) {
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = .maPrintModerationTest(fit, options, par = "effectSize"),
+      "y"     = tempRow,
+      "est"   = NA,
+      "lCi"   = NA,
+      "uCi"   = NA,
+      "test"  = "",
+      "face"  = NA
+    )
+    tempRow <- tempRow + 1
+  }
+
+  if (.maIsMetaregressionHeterogeneity(options) && options[["forestPlotHeterogeneityModerationTest"]]) {
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = .maPrintModerationTest(fit, options, par = "heterogeneity"),
+      "y"     = tempRow,
+      "est"   = NA,
+      "lCi"   = NA,
+      "uCi"   = NA,
+      "test"  = "",
+      "face"  = NA
+    )
+    tempRow <- tempRow + 1
+  }
+
+  if (options[["forestPlotEffectSizeFixedEffectEstimate"]]) {
+
+    pooledEffectSizeTestsRight <- options[["forestPlotEffectSizeFixedEffectTest"]] && options[["forestPlotTestsInRightPanel"]]
+    pooledEffectSizeTestsBelow <- options[["forestPlotEffectSizeFixedEffectTest"]] && !options[["forestPlotTestsInRightPanel"]] && options[["forestPlotPredictionIntervals"]]
+    pooledEffectSizeTestsLeft  <- options[["forestPlotEffectSizeFixedEffectTest"]] && !options[["forestPlotTestsInRightPanel"]] && !options[["forestPlotPredictionIntervals"]]
+
+    tempPooledEstimate <- .maComputePooledEffectPlot(fit, options, forceFixed = TRUE)
+    tempTestText       <- .maPrintCoefficientTest(tempPooledEstimate, options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue")
+
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = if (pooledEffectSizeTestsLeft) paste0(gettext("Fixed Effect Estimate"), ": ", tempTestText) else gettext("Fixed Effect Estimate"),
+      "y"     = tempRow,
+      "est"   = tempPooledEstimate$est,
+      "lCi"   = tempPooledEstimate$lCi,
+      "uCi"   = tempPooledEstimate$uCi,
+      "test"  = if (pooledEffectSizeTestsRight) tempTestText else "",
+      "face"  = NA
+    )
+    additionalObjects[[tempRow]] <- with(tempPooledEstimate, .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
+    tempRow <- tempRow + 1
+
+    if (pooledEffectSizeTestsBelow) {
+      additionalInformation[[tempRow]] <- data.frame(
+        "label" = if (pooledEffectSizeTestsBelow) tempTestText else NA,
+        "y"     = tempRow,
+        "est"   = NA,
+        "lCi"   = NA,
+        "uCi"   = NA,
+        "test"  = "",
+        "face"  = NA
+      )
+
+      tempRow <- tempRow + 1
+    }
+  }
+
+  if (options[["forestPlotEffectSizePooledEstimate"]]) {
+
+    pooledEffectSizeTestsRight <- options[["forestPlotEffectSizePooledEstimateTest"]] && options[["forestPlotTestsInRightPanel"]]
+    pooledEffectSizeTestsBelow <- options[["forestPlotEffectSizePooledEstimateTest"]] && !options[["forestPlotTestsInRightPanel"]] && options[["forestPlotPredictionIntervals"]]
+    pooledEffectSizeTestsLeft  <- options[["forestPlotEffectSizePooledEstimateTest"]] && !options[["forestPlotTestsInRightPanel"]] && !options[["forestPlotPredictionIntervals"]]
+
+    tempPooledEstimate <- .maComputePooledEffectPlot(fit, options)
+    tempTestText      <- .maPrintCoefficientTest(tempPooledEstimate, options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue")
+
+    additionalInformation[[tempRow]] <- data.frame(
+      "label" = if (pooledEffectSizeTestsLeft) paste0(gettext("Pooled Estimate"), ": ", tempTestText) else gettext("Pooled Estimate"),
+      "y"     = tempRow,
+      "est"   = tempPooledEstimate$est,
+      "lCi"   = tempPooledEstimate$lCi,
+      "uCi"   = tempPooledEstimate$uCi,
+      "test"  = if (pooledEffectSizeTestsRight) tempTestText else "",
+      "face"  = NA
+    )
+    additionalObjects[[tempRow]] <- with(tempPooledEstimate, .maMakeDiamondDataFrame(est = est, lCi = lCi, uCi = uCi, row = tempRow, id = tempRow))
+    tempRow <- tempRow + 1
+
+    if (pooledEffectSizeTestsBelow || options[["forestPlotPredictionIntervals"]]) {
+      additionalInformation[[tempRow]] <- data.frame(
+        "label" = if (pooledEffectSizeTestsBelow) tempTestText else NA,
+        "y"     = tempRow,
+        "est"   = NA,
+        "lCi"   = if (options[["forestPlotPredictionIntervals"]]) tempPooledEstimate$lPi else NA,
+        "uCi"   = if (options[["forestPlotPredictionIntervals"]]) tempPooledEstimate$uPi else NA,
+        "test"  = "",
+        "face"  = NA
+      )
+
+      if (options[["forestPlotPredictionIntervals"]])
+        additionalObjects[[tempRow]] <- with(tempPooledEstimate, .maMakeRectangleDataFrame(lCi = lPi, uCi = uPi, row = tempRow, id = tempRow))
+
+      tempRow <- tempRow + 1
+    }
+  }
+
+  # return
+  return(list(
+    information = do.call(rbind, additionalInformation),
+    objects     = do.call(rbind, additionalObjects[!sapply(additionalObjects, is.null)])
+  ))
+}
+
+.forestPlotBuildStudyInformationHeader <- function(options, forestInformation, additionalInformation) {
+
+  # get study information panel header
+  leftPanelStudyInformation <- do.call(rbind.data.frame, options[["forestPlotStudyInformationSelectedVariablesSettings"]])
+
+  ### compute the total character width
+  if (options[["forestPlotStudyInformation"]] && length(leftPanelStudyInformation) != 0) {
+    leftPanelStudyInformationChars <- rbind(
+      nchar(leftPanelStudyInformation$title),
+      apply(forestInformation[,leftPanelStudyInformation$value, drop = FALSE], 2, function(x) max(nchar(x), na.rm = TRUE)))
+    leftPanelStudyInformationChars <- apply(leftPanelStudyInformationChars, 2, max) + 2
+    maxCharsLeft <- sum(leftPanelStudyInformationChars)
+  } else {
+    leftPanelStudyInformationChars <- 0
+    maxCharsLeft <- 0
+  }
+  if (length(additionalInformation) != 0) {
+    additionalInformationChars <- max(nchar(additionalInformation$label), na.rm = TRUE)
+    maxCharsLeft <- max(c(maxCharsLeft, additionalInformationChars))
+  } else {
+    additionalInformationChars <- 0
+  }
+
+  # split the columns
+  if (options[["forestPlotAuxiliaryAdjustWidthBasedOnText"]]) {
+    leftPanelRelativeWidths <- c(maxCharsLeft - sum(leftPanelStudyInformationChars), leftPanelStudyInformationChars)
+    leftPanelRelativeWidths[2:length(leftPanelRelativeWidths)] <- leftPanelRelativeWidths[2:length(leftPanelRelativeWidths)] * leftPanelStudyInformation$width
+    leftPanelRelativeWidths <- leftPanelRelativeWidths / sum(leftPanelRelativeWidths)
+    leftPanelStudyInformation$xStart    <- cumsum(leftPanelRelativeWidths[-length(leftPanelRelativeWidths)])
+    leftPanelStudyInformation$xEnd      <- cumsum(leftPanelRelativeWidths)[-1]
+  } else {
+    leftPanelRelativeWidths <- leftPanelStudyInformation$width / sum(leftPanelStudyInformation$width)
+    leftPanelStudyInformation$xStart <- c(0, cumsum(leftPanelRelativeWidths[-length(leftPanelRelativeWidths)]))
+    leftPanelStudyInformation$xEnd   <- cumsum(leftPanelRelativeWidths)
+  }
+
+  attr(leftPanelStudyInformation, "maxChars") <- maxCharsLeft
+  return(leftPanelStudyInformation)
+}
+
+
+.forestPlotHasStudyInformationHeader   <- function(options) {
+
+  # get study information panel header
+  leftPanelStudyInformation <- do.call(rbind.data.frame, options[["forestPlotStudyInformationSelectedVariablesSettings"]])
+
+  # check if any titles specified
+  return(any(leftPanelStudyInformation[["title"]] != ""))
+}
+.forestPlotHasrightPanel               <- function(options, additionalInformation) {
 
   if (!options[["forestPlotStudyInformation"]] && length(additionalInformation) == 0)
     return(FALSE)

--- a/R/forestplot.R
+++ b/R/forestplot.R
@@ -44,6 +44,7 @@
   forestObjects         <- NULL
   additionalInformation <- NULL
   additionalObjects     <- NULL
+  subgroupHeadings      <- NULL
   tempRow <- 1
 
   if (options[["subgroup"]] == "" || (options[["subgroup"]] != "" && options[["forestPlotSubgroupPanelsWithinSubgroup"]])) {
@@ -61,6 +62,13 @@
         doModelInformation       <- TRUE
       }
 
+      # add a subgroup heading
+      if (options[["subgroup"]] != "") {
+        subgroupHeadings[[length(subgroupHeadings) + 1]] <- .forestPlotSubgroupHeading(options, attr(fit[[i]], "subgroup"), tempRow)
+        tempRow <- tempRow + 1
+      }
+
+
       # extract forest input
       if (doForest && length(forestInput) > 0) {
 
@@ -76,16 +84,20 @@
 
         if (!is.null(forestInput[[i]][["prediction"]])) {
           tempForestObjects    <- forestInput[[i]][["prediction"]]
-          tempForestObjects$y  <- tempForestInformation$y + (tempRow - 1)
+          tempForestObjects$y  <- tempForestObjects$y + (tempRow - 1)
           tempForestObjects$id <- paste(tempForestObjects$id, i, sep = "_")
           forestObjects[[length(forestObjects) + 1]]   <- tempForestObjects
         }
 
-        tempRow <- tempRow + nrow(tempForestInformation) + 1
+        tempRow <- max(tempForestInformation$y, na.rm = TRUE) + 2
       }
 
       # extract estimated marginal means input
       if (doEstimatedMarginalMeans && length(estimatedMarginalMeansInput) > 0){
+
+        # add a section heading
+        additionalInformation[[length(additionalInformation) + 1]] <- .forestPlotPanelHeading(gettext("Estimated Marginal Means"), tempRow)
+        tempRow <- tempRow + 1
 
         tempAdditionalInformation   <- estimatedMarginalMeansInput[[i]][["information"]]
         tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
@@ -98,11 +110,15 @@
           additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
         }
 
-        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+        tempRow <- max(tempAdditionalInformation$y, na.rm = TRUE) + 2
       }
 
       # extract model information input
       if (doModelInformation && length(modelInformationInput) > 0) {
+
+        # add a section heading
+        additionalInformation[[length(additionalInformation) + 1]] <- .forestPlotPanelHeading(gettext("Model Information"), tempRow)
+        tempRow <- tempRow + 1
 
         tempAdditionalInformation   <- modelInformationInput[[i]][["information"]]
         tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
@@ -115,7 +131,7 @@
           additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
         }
 
-        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+        tempRow <- max(tempAdditionalInformation$y, na.rm = TRUE) + 2
       }
     }
   } else {
@@ -125,16 +141,22 @@
 
       for (i in seq_along(fit)) {
 
-        # add space for forest header if specified
-        if (.forestPlotHasStudyInformationHeader(options)) {
-          forestHeaderIndex <- c(forestHeaderIndex, tempRow)
-          tempRow           <- tempRow + 1
-        }
-
         # skip individual sections in case a subgroup analysis is performed and we are at the full fit object
         # (which is in the end of the order)
         if (i == length(fit) && options[["subgroup"]] != "")
           next
+
+        # add a subgroup heading
+        if (options[["subgroup"]] != "") {
+          subgroupHeadings[[length(subgroupHeadings) + 1]] <- .forestPlotSubgroupHeading(options, attr(fit[[i]], "subgroup"), tempRow)
+          tempRow <- tempRow + 1
+        }
+
+        # add forest header if specified
+        if (.forestPlotHasStudyInformationHeader(options)) {
+          forestHeaderIndex <- c(forestHeaderIndex, tempRow)
+          tempRow           <- tempRow + 1
+        }
 
         tempForestInformation   <- forestInput[[i]][["forest"]]
         tempForestInformation$y <- tempForestInformation$y + (tempRow - 1)
@@ -142,23 +164,34 @@
 
         if (!is.null(forestInput[[i]][["prediction"]])) {
           tempForestObjects    <- forestInput[[i]][["prediction"]]
-          tempForestObjects$y  <- tempForestInformation$y + (tempRow - 1)
+          tempForestObjects$y  <- tempForestObjects$y + (tempRow - 1)
           tempForestObjects$id <- paste(tempForestObjects$id, i, sep = "_")
           forestObjects[[length(forestObjects) + 1]]   <- tempForestObjects
         }
 
-        tempRow <- tempRow + nrow(tempForestInformation) + 1
+        tempRow <- max(tempForestInformation$y, na.rm = TRUE) + 2
       }
     }
 
     # extract estimated marginal means input
     if (length(estimatedMarginalMeansInput) > 0){
 
+      # add a section heading
+      additionalInformation[[length(additionalInformation) + 1]] <- .forestPlotPanelHeading(gettext("Estimated Marginal Means"), tempRow)
+      tempRow <- tempRow + 1
+
       for (i in seq_along(fit)) {
 
         # skip individual sections in case a subgroup analysis is performed and we are at the full fit object
         if (i == length(fit) && options[["subgroup"]] != "" && !options[["forestPlotSubgroupFullDatasetEstimatedMarginalMeans"]])
           next
+
+        # add a subgroup heading
+        if (options[["subgroup"]] != "") {
+          subgroupHeadings[[length(subgroupHeadings) + 1]] <- .forestPlotSubgroupHeading(options, attr(fit[[i]], "subgroup"), tempRow)
+          tempRow <- tempRow + 1
+        }
+
 
         tempAdditionalInformation   <- estimatedMarginalMeansInput[[i]][["information"]]
         tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
@@ -171,18 +204,28 @@
           additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
         }
 
-        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+        tempRow <- max(tempAdditionalInformation$y, na.rm = TRUE) + 2
       }
     }
 
     # extract model information input
     if (length(modelInformationInput) > 0) {
 
+      # add a section heading
+      additionalInformation[[length(additionalInformation) + 1]] <- .forestPlotPanelHeading(gettext("Model Information"), tempRow)
+      tempRow <- tempRow + 1
+
       for (i in seq_along(fit)) {
 
         # skip individual sections in case a subgroup analysis is performed and we are at the full fit object
         if (i == length(fit) && options[["subgroup"]] != "" && !options[["forestPlotSubgroupFullDatasetModelInformation"]])
           next
+
+        # add a subgroup heading
+        if (options[["subgroup"]] != "") {
+          subgroupHeadings[[length(subgroupHeadings) + 1]] <- .forestPlotSubgroupHeading(options, attr(fit[[i]], "subgroup"), tempRow)
+          tempRow <- tempRow + 1
+        }
 
         tempAdditionalInformation   <- modelInformationInput[[i]][["information"]]
         tempAdditionalInformation$y <- tempAdditionalInformation$y + (tempRow - 1)
@@ -195,7 +238,7 @@
           additionalObjects[[length(additionalObjects) + 1]]   <- tempAdditionalObjects
         }
 
-        tempRow <- tempRow + nrow(tempAdditionalInformation) + 1
+        tempRow <- max(tempAdditionalInformation$y, na.rm = TRUE) + 2
       }
     }
   }
@@ -210,6 +253,8 @@
     additionalInformation <- do.call(rbind, additionalInformation[!sapply(additionalInformation, is.null)])
   if (!is.null(additionalObjects))
     additionalObjects     <- do.call(rbind, additionalObjects[!sapply(additionalObjects, is.null)])
+  if (!is.null(subgroupHeadings))
+    subgroupHeadings      <- do.call(rbind, subgroupHeadings[!sapply(subgroupHeadings, is.null)])
 
   # adjust y-coordinates
   if (!is.null(forestHeaderIndex))
@@ -222,7 +267,8 @@
     additionalInformation$y <- - additionalInformation$y * options[["forestPlotRelativeSizeRow"]]
   if (!is.null(additionalObjects))
     additionalObjects$y     <- - additionalObjects$y     * options[["forestPlotRelativeSizeRow"]]
-
+  if (!is.null(subgroupHeadings))
+    subgroupHeadings$y      <- - subgroupHeadings$y      * options[["forestPlotRelativeSizeRow"]]
 
   ### make the forest plot ----
   plotForest <- ggplot2::ggplot()
@@ -334,32 +380,36 @@
 
 
   ### make the left information panel ----
-  if ((options[["forestPlotStudyInformation"]] && length(options[["forestPlotStudyInformationSelectedVariablesSettings"]]) > 0) || length(additionalInformation) > 0) {
+  if ((options[["forestPlotStudyInformation"]] && length(options[["forestPlotStudyInformationSelectedVariables"]]) > 0) || length(additionalInformation) > 0) {
 
     plotLeft     <- ggplot2::ggplot()
     maxCharsLeft <- NULL
 
     # add forest information
-    if (options[["forestPlotStudyInformation"]] && length(options[["forestPlotStudyInformationSelectedVariablesSettings"]]) > 0) {
+    if (options[["forestPlotStudyInformation"]] && length(options[["forestPlotStudyInformationSelectedVariables"]]) > 0) {
 
       # build the study information header
       leftPanelStudyInformation <- .forestPlotBuildStudyInformationHeader(options, forestInformation, additionalInformation)
       maxCharsLeft              <- attr(leftPanelStudyInformation, "maxChars")
 
-      # compute study information coordinates
+      # compute study information x-coordinates
       leftPanelStudyInformation$x <- ifelse(
         leftPanelStudyInformation$alignment == "left", leftPanelStudyInformation$xStart, ifelse(
           leftPanelStudyInformation$alignment == "middle", (leftPanelStudyInformation$xStart + leftPanelStudyInformation$xEnd) / 2, leftPanelStudyInformation$xEnd
         ))
-      leftPanelStudyInformation <- do.call(rbind, lapply(forestHeaderIndex, function(y) {
-        leftPanelStudyInformation$y <- y
-        return(leftPanelStudyInformation)
-      }))
 
       # add titles
-      if (length(leftPanelStudyInformation) > 0) {
+      if (any(leftPanelStudyInformation$title != "")) {
+
+        # create the repeating title information
+        leftPanelTitleInformation <- leftPanelStudyInformation
+        leftPanelTitleInformation <- do.call(rbind, lapply(forestHeaderIndex, function(y) {
+          leftPanelTitleInformation$y <- y
+          return(leftPanelTitleInformation)
+        }))
+
         plotLeft <- plotLeft + ggplot2::geom_text(
-          data    = leftPanelStudyInformation,
+          data    = leftPanelTitleInformation,
           mapping = ggplot2::aes(
             x     = x,
             y     = y,
@@ -367,7 +417,7 @@
             hjust = alignment
           ),
           size     = 4 * options[["forestPlotRelativeSizeText"]],
-          vjust    = "midle",
+          vjust    = "middle",
           fontface = "bold"
         )
       }
@@ -390,7 +440,7 @@
             color = label
           ),
           size     = 4 * options[["forestPlotRelativeSizeText"]],
-          vjust    = "midle",
+          vjust    = "middle",
         )
       }
       if (any(leftPanelStudyInformation$value != options[["forestPlotMappingColor"]])) {
@@ -412,7 +462,7 @@
             hjust = alignment
           ),
           size     = 4 * options[["forestPlotRelativeSizeText"]],
-          vjust    = "midle",
+          vjust    = "middle",
         )
       }
     }
@@ -422,7 +472,7 @@
 
       # subset left panel information only
       leftPanelAdditionalInformation   <- additionalInformation[!is.na(additionalInformation$label),]
-      leftPanelAdditionalInformation$x <- 1
+      leftPanelAdditionalInformation$x <- .forestPlotLeftPanelAlign(options)
       leftPanelAdditionalInformation$face[is.na(leftPanelAdditionalInformation$face)] <- "plain"
       maxCharsLeft <- max(c(maxCharsLeft, max(nchar(leftPanelAdditionalInformation$label))), na.rm = TRUE)
 
@@ -436,17 +486,35 @@
           fontface  = face
         ),
         size     = 4 * options[["forestPlotRelativeSizeText"]],
-        hjust    = "right",
-        vjust    = "midle",
+        hjust    = .forestPlotLeftPanelHjust(options),
+        vjust    = "middle",
       )
     }
+
+    if (length(subgroupHeadings) > 0) {
+      # add subgroup headings
+      subgroupHeadings$x <- .forestPlotLeftPanelAlign(options)
+      plotLeft <- plotLeft + ggplot2::geom_text(
+        data    = subgroupHeadings,
+        mapping     = ggplot2::aes(
+          x         = x,
+          y         = y,
+          label     = label,
+          fontface  = face
+        ),
+        size     = 4 * options[["forestPlotRelativeSizeText"]],
+        hjust    = .forestPlotLeftPanelHjust(options),
+        vjust    = "middle",
+      )
+    }
+
 
   } else {
     plotLeft <- NULL
   }
 
   ### make the right information panel ----
-  if (.forestPlotHasrightPanel(options, additionalInformation)) {
+  if (.forestPlotHasRightPanel(options, additionalInformation)) {
 
     # estimates and confidence intervals
     if (options[["forestPlotEstimatesAndConfidenceIntervals"]]) {
@@ -734,16 +802,56 @@
   additionalVariables <- c(
     if (length(options[["forestPlotStudyInformationSelectedVariables"]]) > 0) unlist(options[["forestPlotStudyInformationSelectedVariables"]]),
     if (options[["forestPlotStudyInformationOrderBy"]] != "")                 options[["forestPlotStudyInformationOrderBy"]],
+    if (options[["forestPlotStudyInformationAggregateBy"]] != "")             options[["forestPlotStudyInformationAggregateBy"]],
     if (options[["forestPlotMappingColor"]] != "")                            options[["forestPlotMappingColor"]],
     if (options[["forestPlotMappingShape"]] != "")                            options[["forestPlotMappingShape"]]
   )
   if (length(additionalVariables) > 0)
     dfForest <- cbind(dfForest, dataset[,additionalVariables,drop=FALSE])
 
-  # TODO: temporal fix for the variable names in the Component list not being properly translated
-  # for (i in seq_along(options[["forestPlotStudyInformationSelectedVariables"]])) {
-  #   options[["forestPlotStudyInformationSelectedVariablesSettings"]][[i]][["value"]] <- options[["forestPlotStudyInformationSelectedVariables"]][[i]]
-  # }
+  # aggregate (cannot be simultanously with predicted effects)
+  if (options[["forestPlotStudyInformationAggregateBy"]] != "" && !options[["forestPlotStudyInformationPredictedEffects"]]) {
+#TODO
+    .forestAggregateForBoxplot <- function(dataset, options, additionalVariables) {
+
+      datasetSplit <- split(dfForest, dataset[[options[["forestPlotStudyInformationAggregateBy"]]]])
+      for (i in seq_along(datasetSplit)) {
+        datasetSplit[[i]]$y <- i
+      }
+
+      datasetSplitUnique   <- datasetSplit[sapply(datasetSplit, nrow) == 1]
+      datasetSplitMultiple <- datasetSplit[sapply(datasetSplit, nrow)  > 1]
+
+      datasetSplitMultiple <- lapply(datasetSplitMultiple, function(df) {
+
+        # create a base of the geom
+        tempGeom <- data.frame(
+          y      = df$y[1],
+          min    = min(df$effectSize),
+          lower  = quantile(df$effectSize, 0.25),
+          middle = median(df$effectSize),
+          upper  = quantile(df$effectSize, 0.75),
+          ymax   = max(df$effectSize),
+          geom   = "boxplot"
+        )
+
+        # add the additional variables
+        for (var in additionalVariables) {
+          tempGeom[[var]] <- .forestPlotAggregateVariable(df[[var]][1])
+        }
+
+        return(tempGeom)
+      })
+
+      datasetSplitMultiple <- lapply()
+      options[["forestPlotStudyInformationSelectedVariables"]]
+
+
+
+    }
+
+
+  }
 
   # re-order
   if (options[["forestPlotStudyInformationOrderBy"]] != "") {
@@ -826,21 +934,6 @@
   estimatedMarginalMeansCoefficientTestsRight <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && options[["forestPlotTestsInRightPanel"]]
   estimatedMarginalMeansCoefficientTestsBelow <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && !options[["forestPlotTestsInRightPanel"]] && options[["forestPlotPredictionIntervals"]]
   estimatedMarginalMeansCoefficientTestsLeft  <- options[["forestPlotEstimatedMarginalMeansCoefficientTests"]] && !options[["forestPlotTestsInRightPanel"]] && !options[["forestPlotPredictionIntervals"]]
-
-  # add header
-  additionalInformation[[tempRow]] <- data.frame(
-    "label"  = gettextf(
-      "Estimated Marginal Means%1$s",
-      if (options[["subgroup"]] != "") gettextf(" (Subgroup: %1$s)", attr(fit, "subgroup")) else ""
-    ),
-    "y"      = tempRow,
-    "est"    = NA,
-    "lCi"    = NA,
-    "uCi"    = NA,
-    "test"   = "",
-    "face"   = "bold"
-  )
-  tempRow <- tempRow + 1
 
   # add marginal estimates
   for (i in seq_along(estimatedMarginalMeansVariables)) {
@@ -985,21 +1078,6 @@
   tempRow <- 1
   additionalInformation <- list()
   additionalObjects     <- list()
-
-  # add Header
-  additionalInformation[[tempRow]] <- data.frame(
-    "label"  = gettextf(
-      "Model Fit%1$s",
-      if (options[["subgroup"]] != "") gettextf(" (Subgroup: %1$s)", attr(fit, "subgroup")) else ""
-    ),
-    "y"     = tempRow,
-    "est"   = NA,
-    "lCi"   = NA,
-    "uCi"   = NA,
-    "test"  = "",
-    "face"  = "bold"
-  )
-  tempRow <- tempRow + 1
 
   if (options[["forestPlotResidualHeterogeneityTest"]]) {
     additionalInformation[[tempRow]] <- data.frame(
@@ -1173,7 +1251,6 @@
     objects     = do.call(rbind, additionalObjects[!sapply(additionalObjects, is.null)])
   ))
 }
-
 .forestPlotBuildStudyInformationHeader <- function(options, forestInformation, additionalInformation) {
 
   # get study information panel header
@@ -1213,8 +1290,6 @@
   attr(leftPanelStudyInformation, "maxChars") <- maxCharsLeft
   return(leftPanelStudyInformation)
 }
-
-
 .forestPlotHasStudyInformationHeader   <- function(options) {
 
   # get study information panel header
@@ -1223,7 +1298,7 @@
   # check if any titles specified
   return(any(leftPanelStudyInformation[["title"]] != ""))
 }
-.forestPlotHasrightPanel               <- function(options, additionalInformation) {
+.forestPlotHasRightPanel               <- function(options, additionalInformation) {
 
   if (!options[["forestPlotStudyInformation"]] && length(additionalInformation) == 0)
     return(FALSE)
@@ -1237,4 +1312,90 @@
     return(TRUE)
   else
     return(FALSE)
+}
+.forestPlotSubgroupHeading             <- function(options, subgroup, tempRow) {
+
+  return(data.frame(
+    "label"  = if (subgroup == gettext("Full dataset")) gettext("Full Dataset") else gettextf("Subgroup: %1$s", subgroup),
+    "y"      = tempRow,
+    "est"    = NA,
+    "lCi"    = NA,
+    "uCi"    = NA,
+    "test"   = "",
+    "face"   = "bold"
+  ))
+}
+.forestPlotPanelHeading                <- function(panel, tempRow) {
+
+  return(data.frame(
+    "label"  = panel,
+    "y"      = tempRow,
+    "est"    = NA,
+    "lCi"    = NA,
+    "uCi"    = NA,
+    "test"   = "",
+    "face"   = "bold"
+  ))
+}
+.forestPlotSubgroupTitles              <- function(options, section, subgroup) {
+
+  # return the default if no subgroups are specified
+  if (options[["subgroup"]] == "")
+    return(section)
+
+  # if output is grouped by subgroups, add a subgroup title only at the beginning: no section needs a subgroup title
+  # handled within the reordering of the data
+  if (options[["forestPlotSubgroupPanelsWithinSubgroup"]])
+    return(section)
+
+  # if output is grouped by panels, add only a subgroup title
+  if (subgroup == gettext("Full dataset")) {
+    return(gettext("Full dataset"))
+  } else {
+    return(gettextf("Subgroup: %2$s"))
+  }
+}
+.forestPlotLeftPanelAlign              <- function(options) {
+  return(switch(
+    options[["forestPlotAllignLeftPanel"]],
+    "left"   = 0,
+    "middle" = 0.5,
+    "right"  = 1
+  ))
+}
+.forestPlotLeftPanelHjust              <- function(options) {
+  return(switch(
+    options[["forestPlotAllignLeftPanel"]],
+    "left"   = 0,
+    "middle" = 0.5,
+    "right"  = 1
+  ))
+}
+.forestPlotAggregateVariable           <- function(x) {
+  if (length(unique(x)) == 1) {
+    return(unique(x))
+  } else {
+    x <- table(x)
+    x <- x[x > 0]
+    xNames <- names(x)
+    xFreqs <- paste0(" (", x, ")")
+    xFreqs[xFreqs == " (1)"] <- ""
+    return(paste0(xNames, xFreqs, collapse = ", "))
+  }
+}
+.forestPlotBoxplot <- function(x) {
+  y <- rnorm(2)
+  df <- data.frame(
+    x = 1,
+    y0 = min(y),
+    y25 = quantile(y, 0.25),
+    y50 = median(y),
+    y75 = quantile(y, 0.75),
+    y100 = max(y)
+  )
+  ggplot(df, aes(x)) +
+    geom_boxplot(
+      aes(ymin = y0, lower = y25, middle = y50, upper = y75, ymax = y100),
+      stat = "identity"
+    )
 }

--- a/inst/qml/ClassicalMetaAnalysis.qml
+++ b/inst/qml/ClassicalMetaAnalysis.qml
@@ -25,7 +25,7 @@ Form
 {
 	VariablesForm
 	{
-		preferredHeight: 450 * preferencesModel.uiScale
+		preferredHeight: 500 * preferencesModel.uiScale
 
 		AvailableVariablesList
 		{
@@ -101,7 +101,7 @@ Form
 			title:				qsTr("Predictors")
 			allowedColumns:		["nominal", "scale"]
 			allowTypeChange:	true
-			info: qsTr("Variables to include as predictors (moderators) in the meta-regression model.")
+			info: qsTr("Variables to include as predictors (moderators) in the meta-regression model. See the 'Model' section for the meta-regression specification details.")
 		}
 
 		AssignedVariablesList
@@ -112,7 +112,7 @@ Form
 			singleVariable:		true
 			enabled:			!sectionAdvanced.permutationTestChecked
 			allowedColumns:		["nominal"]
-			info: qsTr("Variable indicating clustering of effect sizes. This option is disabled when permutation tests are selected.")
+			info: qsTr("Variable indicating clustering of effect sizes for robust variance estimation. If the variable is specified, a cluster-robust tests and confidence intervals are provided. See 'Details' section for additional clustering options. This option is disabled when permutation tests are selected.")
 		}
 
 		AssignedVariablesList
@@ -122,6 +122,16 @@ Form
 			singleVariable:		true
 			allowedColumns:		["nominal"]
 			info: qsTr("Variable containing labels for the studies. Used for labeling outputs and plots.")
+		}
+
+		AssignedVariablesList
+		{
+			name:				"subgroup"
+			id:					subgroup
+			title:				qsTr("Subgroup")
+			singleVariable:		true
+			allowedColumns:		["nominal"]
+			info: qsTr("Variable indicating subgroup stratification. For each subgroup, an independent model is fitted to the corresponding data set subset.")
 		}
 	}
 

--- a/inst/qml/ClassicalMetaAnalysisMultilevelMultivariate.qml
+++ b/inst/qml/ClassicalMetaAnalysisMultilevelMultivariate.qml
@@ -26,7 +26,7 @@ Form
 
 	VariablesForm
 	{
-		preferredHeight: 450 * preferencesModel.uiScale
+		preferredHeight: 525 * preferencesModel.uiScale
 
 		AvailableVariablesList
 		{
@@ -102,6 +102,16 @@ Form
 			singleVariable:		true
 			allowedColumns:		["nominal"]
 			info: qsTr("Variable containing labels for the studies. Used for labeling outputs and plots.")
+		}
+		
+		AssignedVariablesList
+		{
+			name:				"subgroup"
+			id:					subgroup
+			title:				qsTr("Subgroup")
+			singleVariable:		true
+			allowedColumns:		["nominal"]
+			info: qsTr("Variable indicating subgroup stratification. For each subgroup, an independent model is fitted to the corresponding data set subset.")
 		}
 	}
 

--- a/inst/qml/qml_components/ClassicalMetaAnalysisAdvanced.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisAdvanced.qml
@@ -36,7 +36,6 @@ Section
 
 		Group
 		{
-
 			CheckBox
 			{
 				name:		"showMetaforRCode"
@@ -51,6 +50,15 @@ Section
 				text:		qsTr("Weighted estimation")
 				checked:	true
 				info: qsTr("Perform weighted estimation using inverse-variance weights. Uncheck for unweighted estimation.")
+			}
+
+			CheckBox
+			{
+				name:		"includeFullDatasetInSubgroupAnalysis"
+				text:		qsTr("Include full dataset in subgroup analysis")
+				enabled:	subgroup.count == 1
+				checked:	true
+				info: qsTr("Include the full dataset output in the subgroup analysis. This option is only available when the subgroup analysis is selected.")
 			}
 
 			Group

--- a/inst/qml/qml_components/ClassicalMetaAnalysisAdvanced.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisAdvanced.qml
@@ -57,7 +57,7 @@ Section
 				name:		"includeFullDatasetInSubgroupAnalysis"
 				text:		qsTr("Include full dataset in subgroup analysis")
 				enabled:	subgroup.count == 1
-				checked:	true
+				checked:	false
 				info: qsTr("Include the full dataset output in the subgroup analysis. This option is only available when the subgroup analysis is selected.")
 			}
 

--- a/inst/qml/qml_components/ClassicalMetaAnalysisEstimatedMarginalMeans.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisEstimatedMarginalMeans.qml
@@ -98,7 +98,6 @@ Section
 
 			CheckBox
 			{	
-				enabled:	estimatedMarginalMeansEffectSizeSelectedVariables.columnsTypes.includes("nominal")
 				name:		"contrastsEffectSize"
 				label:		qsTr("Contrasts")
 
@@ -191,7 +190,6 @@ Section
 
 			CheckBox
 			{
-				enabled:	estimatedMarginalMeansHeterogeneitySelectedVariables.columnsTypes.includes("nominal")
 				name:		"contrastsHeterogeneity"
 				label:		qsTr("Contrasts")
 

--- a/inst/qml/qml_components/ClassicalMetaAnalysisForestPlot.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisForestPlot.qml
@@ -430,6 +430,37 @@ Section
 				checked:		false
 				info: qsTr("Move test results text to the right panel.")
 			}
+
+			Group
+			{
+				title:		qsTr("Subgroup")
+				enabled:	subgroup.count == 1
+				info:		qsTr("Specify the forest plot behavior in the case of a subgroup analysis. These options is only available when the subgroup analysis is selected.")
+
+				CheckBox
+				{
+					name:			"forestPlotSubgroupPanelsWithinSubgroup"
+					text:			qsTr("Panels within subgroup")
+					checked:		true
+					info: qsTr("Group the output panels within their subgroup membership, i.e., the output panels are presented for each subgroup in a sequential order (i.e., Study information (Subgroup 1), Estimated marginal means (Subgroup 1), Model information (Subgroup 1), Study information (Subgroup 2), Estimated marginal means (Subgroup 2), Model information (Subgroup 2), .... If unchecked, the output is group by the panel membership first, i.e., Study information (Subgroup 1), Study information (Subgroup 2), Esimated marginal means (Subgroup 1), Estimated marginal means (Subgroup 2), Model information (Subgroup 1), Model information (Subgroup 2)...")
+				}
+
+				CheckBox
+				{
+					name:			"forestPlotSubgroupFullDatasetEstimatedMarginalMeans"
+					text:			qsTr("Full dataset estimated marginal means")
+					checked:		true
+					info: qsTr("Include the full dataset estimated marginal means in the forest plot if subgroups are specified. This option overrides the `Include full dataset in subgroup analysis` setting in the `Advanced` section.")
+				}
+
+				CheckBox
+				{
+					name:			"forestPlotSubgroupFullDatasetModelInformation"
+					text:			qsTr("Full dataset model information")
+					checked:		true
+					info: qsTr("Include the full dataset model information in the forest plot if subgroups are specified. This option overrides the `Include full dataset in subgroup analysis` setting in the `Advanced` section.")
+				}
+			}
 		}
 
 		Group

--- a/inst/qml/qml_components/ClassicalMetaAnalysisForestPlot.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisForestPlot.qml
@@ -180,8 +180,7 @@ Section
 			Group
 			{
 				title:		qsTr("Aggregate")
-				enabled:	!forestPlotStudyInformationPredictedEffects.checked
-				info: qsTr("Aggregate the study-level information panel by a variable. Not available if `Predicted effects` is selected.")
+				info: qsTr("Aggregate the study-level information panel by a variable. If selected, `Predicted effects` and all `Study information` in the tight panel is supressed.")
 
 				DropDown
 				{

--- a/inst/qml/qml_components/ClassicalMetaAnalysisForestPlot.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisForestPlot.qml
@@ -121,6 +121,7 @@ Section
 			CheckBox
 			{
 				name:		"forestPlotStudyInformationPredictedEffects"
+				id:			forestPlotStudyInformationPredictedEffects
 				text:		qsTr("Predicted effects")
 				enabled:	effectSize.count == 1 && effectSizeStandardError.count == 1
 				checked:	false
@@ -155,21 +156,70 @@ Section
 
 		Group
 		{
-			title:		qsTr("Order")
-			info: qsTr("Order the study-level information panel by a variable.")
 
-			DropDown
+			Group
 			{
-				name:			"forestPlotStudyInformationOrderBy"
-				label:			qsTr("By")
-				addEmptyValue:	true
-				fieldWidth:		125 * preferencesModel.uiScale
+				title:		qsTr("Order")
+				info: qsTr("Order the study-level information panel by a variable.")
+
+				DropDown
+				{
+					name:			"forestPlotStudyInformationOrderBy"
+					label:			qsTr("By")
+					addEmptyValue:	true
+					fieldWidth:		125 * preferencesModel.uiScale
+				}
+
+				CheckBox
+				{
+					name:		"forestPlotStudyInformationOrderAscending"
+					text:		qsTr("Ascending")
+				}
 			}
 
-			CheckBox
+			Group
 			{
-				name:		"forestPlotStudyInformationOrderAscending"
-				text:		qsTr("Ascending")
+				title:		qsTr("Aggregate")
+				enabled:	!forestPlotStudyInformationPredictedEffects.checked
+				info: qsTr("Aggregate the study-level information panel by a variable. Not available if `Predicted effects` is selected.")
+
+				DropDown
+				{
+					name:			"forestPlotStudyInformationAggregateBy"
+					label:			qsTr("By")
+					addEmptyValue:	true
+					fieldWidth:		125 * preferencesModel.uiScale
+				}
+
+				RadioButtonGroup
+				{
+					name:			"forestPlotStudyInformationAggregateMethod"
+					info: qsTr("Select the method for aggregating the estimates of the study-level information panel.")
+
+					RadioButton
+					{
+						name: 		"boxplot";
+						label: 		qsTr("Boxplot")
+						checked: 	true
+					}
+
+					RadioButton
+					{
+						name: 				"bubbles"
+						label: 				qsTr("Bubbles")
+						childrenOnSameRow: 	true
+
+						DoubleField
+						{
+							name:			"forestPlotStudyInformationAggregateMethodBubbleRelativeSize"
+							label:			qsTr("Relative size")
+							defaultValue:	1
+							min:			0
+							inclusive: 		JASP.None
+							info: qsTr("Set the relative size of the observed estimates.")
+						}
+					}
+				}
 			}
 		}
 	}
@@ -406,29 +456,48 @@ Section
 
 		Group
 		{
-			CheckBox
+			Group
 			{
-				name:		"forestPlotPredictionIntervals"
-				text:		qsTr("Prediction intervals")
-				checked:	true
-				Layout.preferredWidth: 300 * jaspTheme.uiScale
-				info: qsTr("Include prediction intervals of the estimated marginal means and the model information output.")
-			}
+				title:		qsTr("General")
 
-			CheckBox
-			{
-				name:			"forestPlotEstimatesAndConfidenceIntervals"
-				text:			qsTr("Estimates and confidence intervals")
-				checked:		true
-				info: qsTr("Include effect size estimates and confidence intervals summary text in the right panel of the forest plot.")
-			}
+				CheckBox
+				{
+					name:		"forestPlotPredictionIntervals"
+					text:		qsTr("Prediction intervals")
+					checked:	true
+					Layout.preferredWidth: 300 * jaspTheme.uiScale
+					info: qsTr("Include prediction intervals of the estimated marginal means and the model information output.")
+				}
 
-			CheckBox
-			{
-				name:			"forestPlotTestsInRightPanel"
-				text:			qsTr("Tests in right panel")
-				checked:		false
-				info: qsTr("Move test results text to the right panel.")
+				CheckBox
+				{
+					name:			"forestPlotEstimatesAndConfidenceIntervals"
+					text:			qsTr("Estimates and confidence intervals")
+					checked:		true
+					info: qsTr("Include effect size estimates and confidence intervals summary text in the right panel of the forest plot.")
+				}
+
+				CheckBox
+				{
+					name:			"forestPlotTestsInRightPanel"
+					text:			qsTr("Tests in right panel")
+					checked:		false
+					info: qsTr("Move test results text to the right panel.")
+				}
+
+				DropDown
+				{
+					name:			"forestPlotAllignLeftPanel"
+					label:			qsTr("Align left panel")
+					enabled:		forestPlotModelInformation.checked || forestPlotEstimatedMarginalMeans.checked
+					startValue:		"right"
+					info: qsTr("Align text of the `Estimated marginal means` and  `Model Information` sections.")
+					values:		[
+						{ label: qsTr("Left")		, value: "left"		},
+						{ label: qsTr("Middle")		, value: "middle"	},
+						{ label: qsTr("Right")		, value: "right"	}
+					]
+				}
 			}
 
 			Group


### PR DESCRIPTION
adds subgroup analyses to Classical Meta-Analysis and Classical Meta-Analysis (Multilevel/Multivariate)
fixes: https://github.com/jasp-stats/jasp-issues/issues/3215
fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/1147

also adds data aggregation for the forest plot (fixes: https://github.com/jasp-stats/jasp-issues/issues/3368)
+ some additional subgroup handling for the forest plot