### PR TITLE
Release Fixes (Vol VI)

### DIFF
--- a/R/metaanalyticsem.R
+++ b/R/metaanalyticsem.R
@@ -41,11 +41,11 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   .masemFitModels(jaspResults, dataset, options, MASEM = TRUE)
   .masemFitMeasures(jaspResults, options)
 
-  # create summary with model fit statistics (for all models)
-  .masemModelFitTable(jaspResults, options, MASEM = TRUE)
 
-  if (options[["additionalFitMeasures"]])
-    .masemAdditionalFitMeasuresTable(jaspResults, options)
+  if (options[["semFitMeasures"]])
+    .masemSemFitMeasuresTable(jaspResults, options)
+  if (options[["modelFitMeasures"]])
+    .masemModelFitMeasuresTable(jaspResults, options, MASEM = TRUE)
   if (options[["pairwiseModelComparison"]])
     .masemPairwiseModelComparisonTable(jaspResults, options)
 
@@ -480,7 +480,7 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   # 2) a new model was fitted that does not have fit measures
   # the computation takes a bit, so it is worthwhile storing them
 
-  if (!options[["additionalFitMeasures"]])
+  if (!options[["semFitMeasures"]])
     return()
 
   # obtain the model container
@@ -517,26 +517,26 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
 
   return()
 }
-.masemAdditionalFitMeasuresTable   <- function(jaspResults, options) {
+.masemSemFitMeasuresTable   <- function(jaspResults, options) {
 
-  if (!is.null(jaspResults[["additionalFitMeasures"]]))
+  if (!is.null(jaspResults[["semFitMeasures"]]))
     return()
 
   # prepare table
-  additionalFitMeasures <- createJaspTable(gettext("Additional Fit Measures"))
-  additionalFitMeasures$position <- 1.1
-  additionalFitMeasures$dependOn(c(.masemDependencies, "additionalFitMeasures"))
-  jaspResults[["additionalFitMeasures"]] <- additionalFitMeasures
+  semFitMeasures <- createJaspTable(gettext("SEM Fit Measures"))
+  semFitMeasures$position <- 1
+  semFitMeasures$dependOn(c(.masemDependencies, "semFitMeasures"))
+  jaspResults[["semFitMeasures"]] <- semFitMeasures
 
   # add columns
-  additionalFitMeasures$addColumnInfo(name = "name",        type = "string",  title = "")
-  additionalFitMeasures$addColumnInfo(name = "chi2",        type = "number",  title = "\U03C7\U00B2")
-  additionalFitMeasures$addColumnInfo(name = "df",          type = "integer", title = gettext("df"))
-  additionalFitMeasures$addColumnInfo(name = "p",           type = "pvalue",  title = gettext("p"))
-  additionalFitMeasures$addColumnInfo(name = "cfi",         type = "number",  title = gettext("CLI"))
-  additionalFitMeasures$addColumnInfo(name = "tli",         type = "number",  title = gettext("TLI"))
-  additionalFitMeasures$addColumnInfo(name = "rmsea",       type = "number",  title = gettext("RMSEA"))
-  additionalFitMeasures$addColumnInfo(name = "prmsea",      type = "number",  title = gettext("p(RMSEA < 0.05)"))
+  semFitMeasures$addColumnInfo(name = "name",        type = "string",  title = "")
+  semFitMeasures$addColumnInfo(name = "chi2",        type = "number",  title = "\U03C7\U00B2")
+  semFitMeasures$addColumnInfo(name = "df",          type = "integer", title = gettext("df"))
+  semFitMeasures$addColumnInfo(name = "p",           type = "pvalue",  title = gettext("p"))
+  semFitMeasures$addColumnInfo(name = "cfi",         type = "number",  title = gettext("CLI"))
+  semFitMeasures$addColumnInfo(name = "tli",         type = "number",  title = gettext("TLI"))
+  semFitMeasures$addColumnInfo(name = "rmsea",       type = "number",  title = gettext("RMSEA"))
+  semFitMeasures$addColumnInfo(name = "prmsea",      type = "number",  title = gettext("p(RMSEA < 0.05)"))
 
   # exit if not ready
   if(!.masemReady(options) || is.null(jaspResults[["modelContainer"]]))
@@ -581,7 +581,7 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   }
 
   # assign output to table
-  additionalFitMeasures$setData(do.call(rbind, out))
+  semFitMeasures$setData(do.call(rbind, out))
 
   return()
 }

--- a/R/metaanalyticsem.R
+++ b/R/metaanalyticsem.R
@@ -41,11 +41,8 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   .masemFitModels(jaspResults, dataset, options, MASEM = TRUE)
   .masemFitMeasures(jaspResults, options)
 
-  # create summary with model fit statistics (for all models)
-  .masemModelFitTable(jaspResults, options, MASEM = TRUE)
-
-  if (options[["additionalFitMeasures"]])
-    .masemAdditionalFitMeasuresTable(jaspResults, options)
+  if (options[["fitMeasures"]])
+    .masemFitMeasuresTable(jaspResults, options)
   if (options[["pairwiseModelComparison"]])
     .masemPairwiseModelComparisonTable(jaspResults, options)
 
@@ -480,7 +477,7 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   # 2) a new model was fitted that does not have fit measures
   # the computation takes a bit, so it is worthwhile storing them
 
-  if (!options[["additionalFitMeasures"]])
+  if (!options[["fitMeasures"]])
     return()
 
   # obtain the model container
@@ -517,26 +514,26 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
 
   return()
 }
-.masemAdditionalFitMeasuresTable   <- function(jaspResults, options) {
+.masemFitMeasuresTable   <- function(jaspResults, options) {
 
-  if (!is.null(jaspResults[["additionalFitMeasures"]]))
+  if (!is.null(jaspResults[["fitMeasures"]]))
     return()
 
   # prepare table
-  additionalFitMeasures <- createJaspTable(gettext("Additional Fit Measures"))
-  additionalFitMeasures$position <- 1.1
-  additionalFitMeasures$dependOn(c(.masemDependencies, "additionalFitMeasures"))
-  jaspResults[["additionalFitMeasures"]] <- additionalFitMeasures
+  fitMeasures <- createJaspTable(gettext("Fit Measures"))
+  fitMeasures$position <- 1.1
+  fitMeasures$dependOn(c(.masemDependencies, "fitMeasures"))
+  jaspResults[["fitMeasures"]] <- fitMeasures
 
   # add columns
-  additionalFitMeasures$addColumnInfo(name = "name",        type = "string",  title = "")
-  additionalFitMeasures$addColumnInfo(name = "chi2",        type = "number",  title = "\U03C7\U00B2")
-  additionalFitMeasures$addColumnInfo(name = "df",          type = "integer", title = gettext("df"))
-  additionalFitMeasures$addColumnInfo(name = "p",           type = "pvalue",  title = gettext("p"))
-  additionalFitMeasures$addColumnInfo(name = "cfi",         type = "number",  title = gettext("CLI"))
-  additionalFitMeasures$addColumnInfo(name = "tli",         type = "number",  title = gettext("TLI"))
-  additionalFitMeasures$addColumnInfo(name = "rmsea",       type = "number",  title = gettext("RMSEA"))
-  additionalFitMeasures$addColumnInfo(name = "prmsea",      type = "number",  title = gettext("p(RMSEA < 0.05)"))
+  fitMeasures$addColumnInfo(name = "name",        type = "string",  title = "")
+  fitMeasures$addColumnInfo(name = "chi2",        type = "number",  title = "\U03C7\U00B2")
+  fitMeasures$addColumnInfo(name = "df",          type = "integer", title = gettext("df"))
+  fitMeasures$addColumnInfo(name = "p",           type = "pvalue",  title = gettext("p"))
+  fitMeasures$addColumnInfo(name = "cfi",         type = "number",  title = gettext("CLI"))
+  fitMeasures$addColumnInfo(name = "tli",         type = "number",  title = gettext("TLI"))
+  fitMeasures$addColumnInfo(name = "rmsea",       type = "number",  title = gettext("RMSEA"))
+  fitMeasures$addColumnInfo(name = "prmsea",      type = "number",  title = gettext("p(RMSEA < 0.05)"))
 
   # exit if not ready
   if(!.masemReady(options) || is.null(jaspResults[["modelContainer"]]))
@@ -581,7 +578,7 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   }
 
   # assign output to table
-  additionalFitMeasures$setData(do.call(rbind, out))
+  fitMeasures$setData(do.call(rbind, out))
 
   return()
 }

--- a/R/metaanalyticsem.R
+++ b/R/metaanalyticsem.R
@@ -657,21 +657,24 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   # create summary table
   tempSummaryTable <- createJaspTable(title = switch(
     output,
-    "regression"    = gettext("Regression Estimates"),
-    "covariances"   = gettext("Covariance Estimates"),
-    "randomEffects" = gettext("Random Effects Estimates")
+    "regression"      = gettext("Regression Estimates"),
+    "meansIntercepts" = gettext("Mean/Intercept Estimates"),
+    "covariances"     = gettext("Covariance Estimates"),
+    "randomEffects"   = gettext("Random Effects Estimates")
   ))
   tempSummaryTable$position <- switch(
     output,
-    "regression"    = 1,
-    "covariances"   = 2,
-    "randomEffects" = 3
+    "regression"      = 1,
+    "meansIntercepts" = 2,
+    "covariances"     = 3,
+    "randomEffects"   = 4
   )
   tempSummaryTable$dependOn(c(.masemDependencies, "modelSummary", "modelSummaryShowMatrixIndices", switch(
     output,
-    "regression"    = "modelSummaryRegression",
-    "covariances"   = "modelSummaryCovariances",
-    "randomEffects" = "modelSummaryRandomEffects"
+    "regression"      = "modelSummaryRegression",
+    "meansIntercepts" = "modelSummaryMeansIntercepts",
+    "covariances"     = "modelSummaryCovariances",
+    "randomEffects"   = "modelSummaryRandomEffects"
   )))
   tempOutputContainer[[output]] <- tempSummaryTable
 
@@ -706,9 +709,10 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   colnames(tempOutput) <- c("name", "matrix", "row", "col", "estimate", "se", "lCi", "uCi", "lCiMet", "uCiMet", "z", "p")
   tempOutput <- tempOutput[tempOutput$matrix %in% switch(
     output,
-    "regression"    = c("Amatrix", "Amatrixvars", "Mmatrix", "Mmatrixvars"),
-    "covariances"   = "Smatrix",
-    "randomEffects" = c("TauCov", "TauMean")
+    "regression"      = c("Amatrix", "Amatrixvars"),
+    "meansIntercepts" = c("Mmatrix", "Mmatrixvars"),
+    "covariances"     = "Smatrix",
+    "randomEffects"   = c("TauCov", "TauMean")
   ), ,drop=FALSE]
 
   # remove additional columns

--- a/R/metaanalyticsem.R
+++ b/R/metaanalyticsem.R
@@ -46,6 +46,8 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
     .masemSemFitMeasuresTable(jaspResults, options)
   if (options[["modelFitMeasures"]])
     .masemModelFitMeasuresTable(jaspResults, options, MASEM = TRUE)
+  if (options[["modelConvergence"]])
+    .masemModelConvergenceTable(jaspResults, options)
   if (options[["pairwiseModelComparison"]])
     .masemPairwiseModelComparisonTable(jaspResults, options)
 
@@ -592,7 +594,7 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
 
   # prepare table
   pairwiseModelComparison <- createJaspTable(gettext("Pairwise Model Comparison"))
-  pairwiseModelComparison$position <- 1.2
+  pairwiseModelComparison$position <- 1.4
   pairwiseModelComparison$dependOn(c(.masemDependencies, "pairwiseModelComparison"))
   jaspResults[["pairwiseModelComparison"]] <- pairwiseModelComparison
 

--- a/R/metaanalyticsem.R
+++ b/R/metaanalyticsem.R
@@ -41,8 +41,11 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   .masemFitModels(jaspResults, dataset, options, MASEM = TRUE)
   .masemFitMeasures(jaspResults, options)
 
-  if (options[["fitMeasures"]])
-    .masemFitMeasuresTable(jaspResults, options)
+  # create summary with model fit statistics (for all models)
+  .masemModelFitTable(jaspResults, options, MASEM = TRUE)
+
+  if (options[["additionalFitMeasures"]])
+    .masemAdditionalFitMeasuresTable(jaspResults, options)
   if (options[["pairwiseModelComparison"]])
     .masemPairwiseModelComparisonTable(jaspResults, options)
 
@@ -477,7 +480,7 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   # 2) a new model was fitted that does not have fit measures
   # the computation takes a bit, so it is worthwhile storing them
 
-  if (!options[["fitMeasures"]])
+  if (!options[["additionalFitMeasures"]])
     return()
 
   # obtain the model container
@@ -514,26 +517,26 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
 
   return()
 }
-.masemFitMeasuresTable   <- function(jaspResults, options) {
+.masemAdditionalFitMeasuresTable   <- function(jaspResults, options) {
 
-  if (!is.null(jaspResults[["fitMeasures"]]))
+  if (!is.null(jaspResults[["additionalFitMeasures"]]))
     return()
 
   # prepare table
-  fitMeasures <- createJaspTable(gettext("Fit Measures"))
-  fitMeasures$position <- 1.1
-  fitMeasures$dependOn(c(.masemDependencies, "fitMeasures"))
-  jaspResults[["fitMeasures"]] <- fitMeasures
+  additionalFitMeasures <- createJaspTable(gettext("Additional Fit Measures"))
+  additionalFitMeasures$position <- 1.1
+  additionalFitMeasures$dependOn(c(.masemDependencies, "additionalFitMeasures"))
+  jaspResults[["additionalFitMeasures"]] <- additionalFitMeasures
 
   # add columns
-  fitMeasures$addColumnInfo(name = "name",        type = "string",  title = "")
-  fitMeasures$addColumnInfo(name = "chi2",        type = "number",  title = "\U03C7\U00B2")
-  fitMeasures$addColumnInfo(name = "df",          type = "integer", title = gettext("df"))
-  fitMeasures$addColumnInfo(name = "p",           type = "pvalue",  title = gettext("p"))
-  fitMeasures$addColumnInfo(name = "cfi",         type = "number",  title = gettext("CLI"))
-  fitMeasures$addColumnInfo(name = "tli",         type = "number",  title = gettext("TLI"))
-  fitMeasures$addColumnInfo(name = "rmsea",       type = "number",  title = gettext("RMSEA"))
-  fitMeasures$addColumnInfo(name = "prmsea",      type = "number",  title = gettext("p(RMSEA < 0.05)"))
+  additionalFitMeasures$addColumnInfo(name = "name",        type = "string",  title = "")
+  additionalFitMeasures$addColumnInfo(name = "chi2",        type = "number",  title = "\U03C7\U00B2")
+  additionalFitMeasures$addColumnInfo(name = "df",          type = "integer", title = gettext("df"))
+  additionalFitMeasures$addColumnInfo(name = "p",           type = "pvalue",  title = gettext("p"))
+  additionalFitMeasures$addColumnInfo(name = "cfi",         type = "number",  title = gettext("CLI"))
+  additionalFitMeasures$addColumnInfo(name = "tli",         type = "number",  title = gettext("TLI"))
+  additionalFitMeasures$addColumnInfo(name = "rmsea",       type = "number",  title = gettext("RMSEA"))
+  additionalFitMeasures$addColumnInfo(name = "prmsea",      type = "number",  title = gettext("p(RMSEA < 0.05)"))
 
   # exit if not ready
   if(!.masemReady(options) || is.null(jaspResults[["modelContainer"]]))
@@ -578,7 +581,7 @@ MetaAnalyticSem <- function(jaspResults, dataset, options, state = NULL) {
   }
 
   # assign output to table
-  fitMeasures$setData(do.call(rbind, out))
+  additionalFitMeasures$setData(do.call(rbind, out))
 
   return()
 }

--- a/R/sembasedmetaanalysis.R
+++ b/R/sembasedmetaanalysis.R
@@ -194,6 +194,10 @@ SemBasedMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
   }
   corDataset <- try(do.call(metaSEM::Cor2DataFrame, dataCall))
 
+  for (i in seq_along(attr(dataset, "modNames"))) {
+    corDataset$data[[attr(dataset, "modNames")[i]]] <- dataset[[attr(dataset, "modNames")[i]]]
+  }
+
   # fit SEM
   if (!jaspBase::isTryError(tempRam) && !jaspBase::isTryError(corDataset)) {
 

--- a/R/sembasedmetaanalysis.R
+++ b/R/sembasedmetaanalysis.R
@@ -29,7 +29,8 @@ SemBasedMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
   .masemFitModels(jaspResults, dataset, options)
 
   # create summary with model fit statistics (for all models)
-  .masemModelFitTable(jaspResults, options)
+  if (options[["modelFitMeasures"]])
+    .masemModelFitMeasuresTable(jaspResults, options)
 
   if (options[["pairwiseModelComparison"]])
     .masemPairwiseModelComparisonTable(jaspResults, options)
@@ -231,15 +232,15 @@ SemBasedMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
 
   return(tempFit)
 }
-.masemModelFitTable           <- function(jaspResults, options, MASEM = FALSE) {
+.masemModelFitMeasuresTable   <- function(jaspResults, options, MASEM = FALSE) {
 
   if (!is.null(jaspResults[["modelFitTable"]]))
     return()
 
   # prepare table
-  modelFitTable <- createJaspTable(gettext("Model Fit"))
-  modelFitTable$position <- 1
-  modelFitTable$dependOn(if (MASEM) .masemDependencies else .semmetaDependencies)
+  modelFitTable <- createJaspTable(gettext("Model Fit Measures"))
+  modelFitTable$position <- 1.1
+  modelFitTable$dependOn(c("modelFitMeasures", if (MASEM) .masemDependencies else .semmetaDependencies))
   jaspResults[["modelFitTable"]] <- modelFitTable
 
   # add columns

--- a/R/sembasedmetaanalysis.R
+++ b/R/sembasedmetaanalysis.R
@@ -312,6 +312,10 @@ SemBasedMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
         .masemCreateSummaryTable(tempOutputContainer, tempFit, options, output = "regression")
       }
 
+      if (is.null(tempOutputContainer[["summaryTableParameters"]]) && options[["modelSummaryMeansIntercepts"]] && length(options[["means"]] > 0)) {
+        .masemCreateSummaryTable(tempOutputContainer, tempFit, options, output = "meansIntercepts")
+      }
+
       if (is.null(tempOutputContainer[["summaryTableCovariances"]]) && options[["modelSummaryCovariances"]]) {
         .masemCreateSummaryTable(tempOutputContainer, tempFit, options, output = "covariances")
       }

--- a/R/sembasedmetaanalysis.R
+++ b/R/sembasedmetaanalysis.R
@@ -437,9 +437,9 @@ SemBasedMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
 
       nCharNodes = 0,
       nCharEdges = 0,
-      sizeInt    = options[["pathDiagramManifestNodeWidth"]],
-      sizeMan    = options[["pathDiagramLatentNodeWidth"]],
-      sizeLat    = options[["pathDiagramUnitVectorNodeWidth"]],
+      sizeInt    = options[["pathDiagramUnitVectorNodeWidth"]],
+      sizeMan    = options[["pathDiagramManifestNodeWidth"]],
+      sizeLat    = options[["pathDiagramLatentNodeWidth"]],
       nDigits    = options[["pathDiagramNumberOfDigits"]],
       weighted   = FALSE,
 

--- a/inst/qml/MetaAnalyticSem.qml
+++ b/inst/qml/MetaAnalyticSem.qml
@@ -289,6 +289,15 @@ Form
 
 			CheckBox
 			{
+				name:		"modelSummaryMeansIntercepts"
+				label:		qsTr("Means/Intercepts")
+				checked:	true
+				enabled:	means.count > 0
+				info:		qsTr("Show mean and intercept estimates (M-Matrix) in the model summary.")
+			}
+
+			CheckBox
+			{
 				name:		"modelSummaryCovariances"
 				label:		qsTr("Covariances")
 				checked:	false

--- a/inst/qml/MetaAnalyticSem.qml
+++ b/inst/qml/MetaAnalyticSem.qml
@@ -274,6 +274,14 @@ Form
 
 		CheckBox
 		{
+			text:		qsTr("Model convergence")
+			name:		"modelConvergence"
+			checked:	false
+			info:		qsTr("Show a summary of the model convergence.")
+		}
+
+		CheckBox
+		{
 			text:		qsTr("Pairwise model comparison")
 			name:		"pairwiseModelComparison"
 			checked:	false

--- a/inst/qml/MetaAnalyticSem.qml
+++ b/inst/qml/MetaAnalyticSem.qml
@@ -258,8 +258,8 @@ Form
 
 		CheckBox
 		{
-			text:		qsTr("Additional fit measures")
-			name:		"additionalFitMeasures"
+			text:		qsTr("Fit measures")
+			name:		"fitMeasures"
 			checked:	false
 			info:		qsTr("Show a summary of the goodness-of-fit statistics.")
 		}

--- a/inst/qml/MetaAnalyticSem.qml
+++ b/inst/qml/MetaAnalyticSem.qml
@@ -258,10 +258,18 @@ Form
 
 		CheckBox
 		{
-			text:		qsTr("Additional fit measures")
-			name:		"additionalFitMeasures"
+			text:		qsTr("SEM fit measures")
+			name:		"semFitMeasures"
 			checked:	false
-			info:		qsTr("Show a summary of the goodness-of-fit statistics.")
+			info:		qsTr("Show a summary of the SEM goodness-of-fit statistics.")
+		}
+
+		CheckBox
+		{
+			text:		qsTr("Model fit measures")
+			name:		"modelFitMeasures"
+			checked:	false
+			info:		qsTr("Show a summary of the model fit statistics.")
 		}
 
 		CheckBox
@@ -276,7 +284,7 @@ Form
 		{
 			text:		qsTr("Model summary")
 			name:		"modelSummary"
-			checked:	false
+			checked:	true
 			info:		qsTr("Show a summary of the model coefficients and computed estimates.")
 
 			CheckBox

--- a/inst/qml/MetaAnalyticSem.qml
+++ b/inst/qml/MetaAnalyticSem.qml
@@ -258,8 +258,8 @@ Form
 
 		CheckBox
 		{
-			text:		qsTr("Fit measures")
-			name:		"fitMeasures"
+			text:		qsTr("Additional fit measures")
+			name:		"additionalFitMeasures"
 			checked:	false
 			info:		qsTr("Show a summary of the goodness-of-fit statistics.")
 		}

--- a/inst/qml/SemBasedMetaAnalysis.qml
+++ b/inst/qml/SemBasedMetaAnalysis.qml
@@ -104,6 +104,16 @@ Form
 			info:		qsTr("Show a pairwise model comparison table.")
 		}
 
+/*
+		CheckBox
+		{
+			text:		qsTr("Model convergence")
+			name:		"modelConvergence"
+			checked:	false
+			info:		qsTr("Show a summary of the model convergence.")
+		}
+*/
+
 		CheckBox
 		{
 			text:		qsTr("Model summary")

--- a/inst/qml/SemBasedMetaAnalysis.qml
+++ b/inst/qml/SemBasedMetaAnalysis.qml
@@ -87,6 +87,15 @@ Form
 	
 	Group
 	{
+
+		CheckBox
+		{
+			text:		qsTr("Model fit measures")
+			name:		"modelFitMeasures"
+			checked:	false
+			info:		qsTr("Show a summary of the model fit statistics.")
+		}
+
 		CheckBox
 		{
 			text:		qsTr("Pairwise model comparison")
@@ -99,7 +108,7 @@ Form
 		{
 			text:		qsTr("Model summary")
 			name:		"modelSummary"
-			checked:	false
+			checked:	true
 			info:		qsTr("Show a summary of the model coefficients and computed estimates.")
 
 			DropDown

--- a/inst/qml/SemBasedMetaAnalysis.qml
+++ b/inst/qml/SemBasedMetaAnalysis.qml
@@ -99,7 +99,7 @@ Form
 		{
 			text:		qsTr("Model summary")
 			name:		"modelSummary"
-			checked:	true
+			checked:	false
 			info:		qsTr("Show a summary of the model coefficients and computed estimates.")
 
 			DropDown

--- a/inst/qml/SemBasedMetaAnalysis.qml
+++ b/inst/qml/SemBasedMetaAnalysis.qml
@@ -99,7 +99,7 @@ Form
 		{
 			text:		qsTr("Model summary")
 			name:		"modelSummary"
-			checked:	false
+			checked:	true
 			info:		qsTr("Show a summary of the model coefficients and computed estimates.")
 
 			DropDown


### PR DESCRIPTION
Release fixes based on reports I received by mail from Suzanne Jak

fixes: regression and means parameters now displayed in separate output
fixes: mismatched node control arguments
fixes: moderators
reorder the default output and model fit tables
add convergence checks to metaSEM 

