### PR TITLE
Update forest plot UI visibility and enabling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspMetaAnalysis
 Type: Package
 Title: Meta-Analysis Module for JASP
-Version: 0.96.6
+Version: 0.97.0
 Date: 2022-10-05
 Author: JASP Team
 Website: jasp-stats.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 >   * **Deprecated / Removed:** Outdated analyses, options, or legacy code.
 
 ---
+# jaspMetaAnalysis 0.97.0
+## Fixed
+* Forest plot heterogeneity disabling for multilevel/multivariate meta-analysis
+
 # jaspMetaAnalysis 0.96.6
 ## Fixed
 * Diagnostics handling for location-scale models

--- a/R/forestplotdata.R
+++ b/R/forestplotdata.R
@@ -576,10 +576,12 @@
     return(NULL)
 
   classical                   <- .maIsClassical(options)
+  standardClassical           <- .maIsClassical(options, notMHP = TRUE)
   method                      <- .maGetMethodOptions(options)
   randomEffectsMethod         <- !method %in% c("FE", "EE", "MH", "PETO")
   mantelHaenszelMethod        <- method %in% c("MH", "PETO")
   heterogeneityMetaregression <- .maIsMetaregressionHeterogeneity(options)
+  scaleRegression             <- options[["analysis"]] == "metaAnalysis" && heterogeneityMetaregression
   testsStatistics             <- options[["forestPlotAuxiliaryTestsInformation"]] == "statisticAndPValue"
 
   state <- .forestPlotCreateAdditionalSectionState()
@@ -672,7 +674,12 @@
     )
   }
 
-  if (options[["forestPlotEffectSizeFixedEffectEstimate"]]) {
+  if (
+    standardClassical &&
+    randomEffectsMethod &&
+    !scaleRegression &&
+    options[["forestPlotEffectSizeFixedEffectEstimate"]]
+  ) {
 
     fixedEffectTestPlacement <- .forestPlotResolveTestPlacement(
       options[["forestPlotEffectSizeFixedEffectTest"]],

--- a/inst/qml/qml_components/ForestPlotSection.qml
+++ b/inst/qml/qml_components/ForestPlotSection.qml
@@ -214,13 +214,14 @@ Section
 				title:		qsTr("Estimate")
 				columns:	2
 				enabled:	!isFixedOrEqualEffect
+				visible:	analysisType !== "multilevelMultivariateMetaAnalysis"
 
 				CheckBox
 				{
 					text:		qsTr("\uD835\uDF0F")
 					name:		"forestPlotHeterogeneityEstimateTau"
-					visible:	analysisType !== "mantelHaenszelPeto"
-					checked:	analysisType !== "mantelHaenszelPeto"
+					visible:	analysisType !== "mantelHaenszelPeto" && analysisType !== "multilevelMultivariateMetaAnalysis"
+					checked:	analysisType !== "mantelHaenszelPeto" && analysisType !== "multilevelMultivariateMetaAnalysis"
 					info: qsTr("Include the meta-analytic \uD835\uDF0F, the square root of the estimated between-study variance in the model information section. Not available for multilevel/multivariate meta-analysis.")
 				}
 
@@ -228,7 +229,7 @@ Section
 				{
 					text:		qsTr("\uD835\uDF0F\u00B2")
 					name:		"forestPlotHeterogeneityEstimateTau2"
-					visible:	analysisType !== "mantelHaenszelPeto"
+					visible:	analysisType !== "mantelHaenszelPeto" && analysisType !== "multilevelMultivariateMetaAnalysis"
 					checked:	false
 					info: qsTr("Include the meta-analytic \uD835\uDF0F\u00B2, the estimated between-study variance in the model information section. Not available for multilevel/multivariate meta-analysis.")
 				}
@@ -237,18 +238,20 @@ Section
 				{
 					text:		qsTr("I\u00B2")
 					name:		"forestPlotHeterogeneityEstimateI2"
-					enabled:	analysisType !== "mantelHaenszelPeto" && !isScaleRegression
+					enabled:	analysisType !== "multilevelMultivariateMetaAnalysis" && !isScaleRegression
+					visible:	analysisType !== "multilevelMultivariateMetaAnalysis"
 					checked:	false
-					info: qsTr("Include the meta-analytic I\u00B2, the percentage of total variation across studies due to heterogeneity in the model information section. Not available for multilevel/multivariate and binomial meta-analysis.")
+					info: qsTr("Include the meta-analytic I\u00B2, the percentage of total variation across studies due to heterogeneity in the model information section. Not available for multilevel/multivariate meta-analysis or heterogeneity meta-regression.")
 				}
 
 				CheckBox
 				{
 					text:		qsTr("H\u00B2")
 					name:		"forestPlotHeterogeneityEstimateH2"
-					enabled:	analysisType !== "mantelHaenszelPeto" && !isScaleRegression
+					enabled:	analysisType !== "multilevelMultivariateMetaAnalysis" && !isScaleRegression
+					visible:	analysisType !== "multilevelMultivariateMetaAnalysis"
 					checked:	false
-					info: qsTr("Include the meta-analytic H\u00B2, an index indicating the ratio of total variability to sampling variability in the model information section. Not available for multilevel/multivariate and binomial meta-analysis.")
+					info: qsTr("Include the meta-analytic H\u00B2, an index indicating the ratio of total variability to sampling variability in the model information section. Not available for multilevel/multivariate meta-analysis or heterogeneity meta-regression.")
 				}
 			}
 
@@ -274,7 +277,7 @@ Section
 				id:			forestPlotEffectSizeFixedEffectEstimate
 				checked:	false
 				visible:	isStandardClassical
-				enabled:	isStandardClassical && !isFixedOrEqualEffect
+				enabled:	isStandardClassical && !isFixedOrEqualEffect && !isScaleRegression
 				info: qsTr("Include a fixed effect meta-analytic effect size estimate in the model information section. Not available if the model was already fitted with fixed effects or the model contains heterogeneity meta-regression.")
 			}
 
@@ -284,7 +287,7 @@ Section
 				text:		qsTr("Fixed effect estimate test")
 				checked:	true
 				visible:	isStandardClassical 
-				enabled:	isStandardClassical && !isFixedOrEqualEffect && forestPlotEffectSizeFixedEffectEstimate.checked
+				enabled:	isStandardClassical && !isFixedOrEqualEffect && !isScaleRegression && forestPlotEffectSizeFixedEffectEstimate.checked
 				info: qsTr("Include the test of the fixed effect meta-analytic effect size estimate in the model information section.")
 			}
 
@@ -315,9 +318,9 @@ Section
 			{
 				name:		"forestPlotEffectSizeModerationTest"
 				text:		qsTr("Moderation test")
-				enabled:	isClassical && analysisType !== "mantelHaenszelPeto"
+				enabled:	isClassical && isMetaRegression
 				visible: 	isClassical && analysisType !== "mantelHaenszelPeto"
-				checked:	isClassical && analysisType !== "mantelHaenszelPeto"
+				checked:	isClassical && isMetaRegression
 				info: qsTr("Include the omnibus effect size moderation test in the model information section. Available when effect size meta-regression is specified.")
 			}
 		}

--- a/renv.lock
+++ b/renv.lock
@@ -3970,7 +3970,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspBase",
       "RemoteRef": "master",
-      "RemoteSha": "209d1787d5c9400601df960535b261029a350b12",
+      "RemoteSha": "f1944101ee749e3fcd605defca2e014ade4b3534",
       "Remotes": "jasp-stats/jaspGraphs"
     },
     "jaspGraphs": {
@@ -4009,7 +4009,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspGraphs",
       "RemoteRef": "master",
-      "RemoteSha": "cac753920e984d3628cace64538c00acd3622a58"
+      "RemoteSha": "71166504a369b1bc0263611c551bec62773f9338"
     },
     "jaspSem": {
       "Package": "jaspSem",
@@ -4046,7 +4046,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspSem",
       "RemoteRef": "master",
-      "RemoteSha": "55c014ba2fcde91f1a7939a51a7e649342f52340",
+      "RemoteSha": "4e5a68caf048e4bd3ff286832b341f4ab8b93443",
       "Remotes": "jasp-stats/jaspBase, jasp-stats/jaspGraphs"
     },
     "jaspTools": {
@@ -4089,7 +4089,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspTools",
       "RemoteRef": "master",
-      "RemoteSha": "281f17a2d6761eb5ec247d7ddcd59042f01fa409"
+      "RemoteSha": "55ab6bcd2e3828fc923a9bdf513c50a06da3d6ad"
     },
     "jpeg": {
       "Package": "jpeg",


### PR DESCRIPTION
Hide and disable forest plot options that are not applicable to multilevel/multivariate meta-analysis and scale-regression models. 

Added visibility checks to the Estimate section and individual heterogeneity checkboxes (tau, tau^2, I^2, H^2) for analysisType === "multilevelMultivariateMetaAnalysis", adjusted enabled/checked conditions to also exclude multilevel/multivariate and scale-regression cases, and updated informational text for I^2 and H^2. Also prevent fixed-effect estimate/test when scale regression is present and require isMetaRegression for the moderation test. These changes ensure the UI only presents valid options for the selected analysis type.