### PR TITLE
Fix glmm diagnostics and exports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspMetaAnalysis
 Type: Package
 Title: Meta-Analysis Module for JASP
-Version: 0.97.2
+Version: 0.97.3
 Date: 2022-10-05
 Author: JASP Team
 Website: jasp-stats.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 ## Fixed
 * Restored GLMM diagnostics and exports, exposing variance inflation factors, raw residuals, and predicted values.
 * Added study-level variability and random-effects correlation estimates for unconditional models with random study effects.
+* Added optional prefixes for columns exported by classical meta-analyses, requiring them for additional analyses while preserving the original prefixless export.
+* Added clear errors when casewise diagnostics cannot be computed, without terminating analyses unless their export is requested.
 
 # jaspMetaAnalysis 0.97.2
 ## Fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 >   * **Deprecated / Removed:** Outdated analyses, options, or legacy code.
 
 ---
+# jaspMetaAnalysis 0.97.3
+## Fixed
+* Restored GLMM diagnostics and exports, exposing variance inflation factors, raw residuals, and predicted values.
+
 # jaspMetaAnalysis 0.97.2
 ## Fixed
 * Meta-analytic SEM failing to load because JASP wipes OpenMx `mxOptions` before `metaSEM` `.onLoad`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 # jaspMetaAnalysis 0.97.3
 ## Fixed
 * Restored GLMM diagnostics and exports, exposing variance inflation factors, raw residuals, and predicted values.
+* Added study-level variability and random-effects correlation estimates for unconditional models with random study effects.
 
 # jaspMetaAnalysis 0.97.2
 ## Fixed

--- a/R/classicalgeneralizedmetaanalysis.R
+++ b/R/classicalgeneralizedmetaanalysis.R
@@ -276,7 +276,7 @@ ClassicalGeneralizedMetaAnalysis <- function(jaspResults, dataset = NULL, option
 }
 
 # heterogeneity
-.maglmmComputePooledHeterogeneity <- function(fit, options) {
+.maglmmComputePooledHeterogeneity <- function(fit, options, includeModelComponents = TRUE) {
 
   # derive I²/H² CIs from tau² CIs via monotonic transformation when available
   vt        <- fit[["vt"]]
@@ -312,6 +312,34 @@ ClassicalGeneralizedMetaAnalysis <- function(jaspResults, dataset = NULL, option
 
   heterogeneity <- heterogeneity[heterogeneityShow, , drop = FALSE]
 
+  if (includeModelComponents && identical(fit[["model"]], "UM.RS")) {
+    componentPar <- c(
+      if (options[["heterogeneityTau"]]  && .maIsFiniteScalar(fit[["sigma2"]])) "\u03C3",
+      if (options[["heterogeneityTau2"]] && .maIsFiniteScalar(fit[["sigma2"]])) "\u03C3\u00B2",
+      if (.maIsFiniteScalar(fit[["rho"]])) "\u03C1"
+    )
+    componentEst <- c(
+      if (options[["heterogeneityTau"]]  && .maIsFiniteScalar(fit[["sigma2"]])) sqrt(fit[["sigma2"]]),
+      if (options[["heterogeneityTau2"]] && .maIsFiniteScalar(fit[["sigma2"]])) fit[["sigma2"]],
+      if (.maIsFiniteScalar(fit[["rho"]])) fit[["rho"]]
+    )
+
+    if (length(componentPar) == 0)
+      return(heterogeneity)
+
+    modelComponents <- data.frame(
+      par = componentPar,
+      est = componentEst,
+      lCi = rep(NA_real_, length(componentPar)),
+      uCi = rep(NA_real_, length(componentPar))
+    )
+
+    if ("se" %in% names(heterogeneity))
+      modelComponents$se <- NA_real_
+
+    heterogeneity <- rbind(heterogeneity, modelComponents[, names(heterogeneity), drop = FALSE])
+  }
+
   return(heterogeneity)
 }
 
@@ -322,7 +350,7 @@ ClassicalGeneralizedMetaAnalysis <- function(jaspResults, dataset = NULL, option
   options[["heterogeneityI2"]]   <- parameter == "I2"
   options[["heterogeneityH2"]]   <- parameter == "H2"
 
-  confIntHeterogeneity <- .maglmmComputePooledHeterogeneity(fit, options)
+  confIntHeterogeneity <- .maglmmComputePooledHeterogeneity(fit, options, includeModelComponents = FALSE)
 
   return(confIntHeterogeneity)
 }

--- a/R/classicalmetaanalysis-diagnostics.R
+++ b/R/classicalmetaanalysis-diagnostics.R
@@ -41,7 +41,10 @@
         influenceResultsDfbs <- list()
         influenceResultsInf  <- list()
       } else {
-        if (.maIsMultilevelMultivariate(options)) {
+        if (.maIsGLMM(options)) {
+          influenceResultsDfbs <- data.frame()
+          influenceResultsInf  <- data.frame()
+        } else if (.maIsMultilevelMultivariate(options)) {
           # only a subset of diagnostics is available for rma.mv
           influenceResultsDfbs <- data.frame(dfbetas(fit[[i]], code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics: DFBETAS')", code2 = "jaspBase::progressbarTick()"))
           influenceResultsInf  <- data.frame(

--- a/R/classicalmetaanalysis-diagnostics.R
+++ b/R/classicalmetaanalysis-diagnostics.R
@@ -38,41 +38,19 @@
     for (i in seq_along(fit)) {
 
       if (jaspBase::isTryError(fit[[i]])) {
-        influenceResultsDfbs <- list()
-        influenceResultsInf  <- list()
+        diagnostics <- list(
+          "influenceResultsDfbs" = list(),
+          "influenceResultsInf"  = list()
+        )
       } else {
-        if (.maIsGLMM(options)) {
-          influenceResultsDfbs <- data.frame()
-          influenceResultsInf  <- data.frame()
-        } else if (.maIsMultilevelMultivariate(options)) {
-          # only a subset of diagnostics is available for rma.mv
-          influenceResultsDfbs <- data.frame(dfbetas(fit[[i]], code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics: DFBETAS')", code2 = "jaspBase::progressbarTick()"))
-          influenceResultsInf  <- data.frame(
-            rstudent = rstudent(fit[[i]],       code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics: Studentized residuals')", code2 = "jaspBase::progressbarTick()")[["resid"]],
-            cook.d   = cooks.distance(fit[[i]], code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics: Cooks distance')",        code2 = "jaspBase::progressbarTick()"),
-            hat      = hatvalues(fit[[i]])
-          )
-        } else if (.maIsMetaregressionHeterogeneity(options)) {
-          influenceResultsDfbs <- data.frame()
-          influenceResultsInf  <- data.frame(
-            rstudent = stats::rstandard(fit[[i]])[["z"]],
-            hat      = hatvalues(fit[[i]]),
-            weight   = stats::weights(fit[[i]], type = "diagonal")
-          )
-        } else {
-          # the complete suite of influence diagnostics is only available for rma.uni
-          influenceResults     <- influence(fit[[i]], code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics')", code2 = "jaspBase::progressbarTick()")
-          influenceResultsDfbs <- data.frame(influenceResults$dfbs)
-          influenceResultsInf  <- data.frame(influenceResults$inf)
-          influenceResultsInf$tau.del <- sqrt(influenceResultsInf$tau2.del)
-          influenceResultsInf$inf[influenceResultsInf$inf == "*"] <- "Yes"
+        diagnostics <- try(.maComputeDiagnostics(fit[[i]], options), silent = TRUE)
+        if (jaspBase::isTryError(diagnostics)) {
+          jaspResults[["diagnosticsResults"]]$object <- diagnostics
+          return(diagnostics)
         }
       }
 
-      out[[attr(fit[[i]], "subgroup")]] <- list(
-        "influenceResultsDfbs" = influenceResultsDfbs,
-        "influenceResultsInf"  = influenceResultsInf
-      )
+      out[[attr(fit[[i]], "subgroup")]] <- diagnostics
     }
 
     # store the results
@@ -80,6 +58,53 @@
   }
 
   return(out)
+}
+
+.maComputeDiagnostics            <- function(fit, options) {
+
+  if (.maIsGLMM(options)) {
+    influenceResultsDfbs <- data.frame()
+    influenceResultsInf  <- data.frame()
+  } else if (.maIsMultilevelMultivariate(options)) {
+    # only a subset of diagnostics is available for rma.mv
+    influenceResultsDfbs <- data.frame(dfbetas(fit, code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics: DFBETAS')", code2 = "jaspBase::progressbarTick()"))
+    influenceResultsInf  <- data.frame(
+      rstudent = rstudent(fit,       code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics: Studentized residuals')", code2 = "jaspBase::progressbarTick()")[["resid"]],
+      cook.d   = cooks.distance(fit, code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics: Cooks distance')",        code2 = "jaspBase::progressbarTick()"),
+      hat      = hatvalues(fit)
+    )
+  } else if (.maIsMetaregressionHeterogeneity(options)) {
+    influenceResultsDfbs <- data.frame()
+    influenceResultsInf  <- data.frame(
+      rstudent = stats::rstandard(fit)[["z"]],
+      hat      = hatvalues(fit),
+      weight   = stats::weights(fit, type = "diagonal")
+    )
+  } else {
+    # the complete suite of influence diagnostics is only available for rma.uni
+    influenceResults     <- influence(fit, code1 = "jaspBase::startProgressbar(x$k, label = 'Casewise diagnostics')", code2 = "jaspBase::progressbarTick()")
+    influenceResultsDfbs <- data.frame(influenceResults$dfbs)
+    influenceResultsInf  <- data.frame(influenceResults$inf)
+    influenceResultsInf$tau.del <- sqrt(influenceResultsInf$tau2.del)
+    influenceResultsInf$inf[influenceResultsInf$inf == "*"] <- "Yes"
+  }
+
+  return(list(
+    "influenceResultsDfbs" = influenceResultsDfbs,
+    "influenceResultsInf"  = influenceResultsInf
+  ))
+}
+
+.maDiagnosticsErrorMessage       <- function(diagnostics) {
+
+  if (!jaspBase::isTryError(diagnostics))
+    return(NULL)
+
+  errorMessage <- conditionMessage(attr(diagnostics, "condition"))
+  if (grepl("not positive", errorMessage, fixed = TRUE))
+    return(gettext("Casewise diagnostics could not be computed because the model coefficient covariance matrix is not positive definite. This can occur with the Knapp and Hartung adjustment when effect sizes are identical or nearly identical. Try changing the fixed effects test or revising the model."))
+
+  return(gettextf("Casewise diagnostics could not be computed: %1$s", errorMessage))
 }
 
 .maProfile                       <- function(jaspResults, options) {
@@ -252,6 +277,11 @@
   ### the computation needs to be done before the table to get all the necessary information on column names
   # export diagnostics
   diagnostics <- .maDiagnostics(jaspResults, options)
+  diagnosticsError <- .maDiagnosticsErrorMessage(diagnostics)
+  if (!is.null(diagnosticsError)) {
+    casewiseDiagnosticsTable$setError(diagnosticsError)
+    return()
+  }
 
   # always drop the full from subgroups
   if (options[["subgroup"]] != "" && options[["includeFullDatasetInSubgroupAnalysis"]]) {

--- a/R/classicalmetaanalysis-exports.R
+++ b/R/classicalmetaanalysis-exports.R
@@ -5,6 +5,10 @@
 # Export orchestration ----
 
 .maCasewiseDiagnosticsExportColumns      <- function(jaspResults, dataset, options) {
+  if (!.maAnyDiagnosticsExportColumns(options) || is.null(dataset) || !.maReady(options))
+    return()
+
+  .maValidateExportPrefix(options)
   .maExportDiagnosticsColumns(jaspResults, dataset, options)
   return()
 }
@@ -13,6 +17,8 @@
 
   if (!.maAnyExportColumns(options) || is.null(dataset) || !.maReady(options))
     return()
+
+  .maValidateExportPrefix(options)
 
   .maExportDiagnosticsColumns(jaspResults, dataset, options)
   .maExportResidualColumns(jaspResults, dataset, options)
@@ -30,6 +36,83 @@
   return(any(vapply(exportOptions, function(option) isTRUE(options[[option]]), logical(1))))
 }
 
+.maValidateExportPrefix                  <- function(options) {
+
+  if (.maExportColumnPrefix(options) == "") {
+    ownership <- .maExportColumnOwnership()
+    if (ownership[["otherAnalysis"]] && !ownership[["ownsUnprefixed"]])
+      .quitAnalysis(gettext("Another analysis has already exported columns. Specify a prefix for the exported column names before exporting from this analysis."))
+  }
+
+  return()
+}
+
+.maExportColumnOwnership                 <- function() {
+
+  allColumnNamesDataset <- get0(".allColumnNamesDataset", envir = .GlobalEnv, mode = "function", inherits = FALSE)
+  if (is.null(allColumnNamesDataset))
+    return(c(ownsUnprefixed = FALSE, otherAnalysis = FALSE))
+
+  columnNames  <- allColumnNamesDataset()
+  decodedNames <- jaspBase::decodeColNames(columnNames)
+  exported     <- .maIsExportColumnName(decodedNames)
+  if (!any(exported))
+    return(c(ownsUnprefixed = FALSE, otherAnalysis = FALSE))
+
+  isMine <- vapply(columnNames[exported], jaspBase:::columnIsMine, logical(1))
+
+  return(c(
+    ownsUnprefixed = any(isMine & .maIsExportColumnName(decodedNames[exported], allowPrefix = FALSE)),
+    otherAnalysis  = any(!isMine)
+  ))
+}
+
+.maIsExportColumnName                    <- function(columnName, allowPrefix = TRUE) {
+
+  exportNamePattern <- paste0(
+    if (allowPrefix) "(^|: )(" else "^(",
+    "Diagnostics:|",
+    "Residuals:|",
+    "Predicted Values:|",
+    "True Effect Estimates \\(BLUPs\\):|",
+    "Random Effects:|",
+    "Weights($|:)|",
+    "Difference in coefficients:",
+    ")"
+  )
+
+  return(grepl(exportNamePattern, columnName))
+}
+
+.maExportColumnName                      <- function(columnName, options) {
+
+  prefix <- .maExportColumnPrefix(options)
+  if (prefix == "")
+    return(columnName)
+
+  return(paste0(prefix, ": ", columnName))
+}
+
+.maExportColumnPrefix                    <- function(options) {
+
+  if (!isTRUE(options[["exportColumnPrefix"]]))
+    return("")
+
+  prefix <- options[["exportColumnPrefixValue"]]
+  if (is.null(prefix) || length(prefix) != 1 || is.na(prefix))
+    return("")
+
+  return(trimws(prefix))
+}
+
+.maValidateExportColumnName              <- function(columnName) {
+
+  if (jaspBase:::columnExists(columnName) && !jaspBase:::columnIsMine(columnName))
+    .quitAnalysis(gettext("Another analysis already exported columns with the same names. Specify a unique prefix for the exported column names."))
+
+  return()
+}
+
 # Diagnostic exports ----
 
 .maExportDiagnosticsColumns              <- function(jaspResults, dataset, options) {
@@ -44,6 +127,9 @@
     return()
 
   diagnostics <- .maDiagnostics(jaspResults, options)
+  diagnosticsError <- .maDiagnosticsErrorMessage(diagnostics)
+  if (!is.null(diagnosticsError))
+    .quitAnalysis(diagnosticsError)
 
   if (options[["subgroup"]] != "" && isTRUE(options[["includeFullDatasetInSubgroupAnalysis"]]))
     diagnostics <- diagnostics[-1]
@@ -67,19 +153,19 @@
     .maExportUnavailableDiagnosticsColumns(jaspResults, dataset, options)
 
   if (.maExportDiagnosticsInfluentialCases(options) && "inf" %in% colnames(diagnosticsTable))
-    .maExportNominalColumn(jaspResults, "Diagnostics: Influential", diagnosticsTable[["inf"]], c(.maExportDependencies(), "exportDiagnosticsInfluentialCases"))
+    .maExportNominalColumn(jaspResults, "Diagnostics: Influential", diagnosticsTable[["inf"]], c(.maExportDependencies(), "exportDiagnosticsInfluentialCases"), options)
 
   if (.maExportDiagnosticsCaseDiagnostics(options)) {
     for (diagnosticName in intersect(c("rstudent", "cook.d", "hat", "weight"), colnames(diagnosticsTable))) {
       columnName <- paste0("Diagnostics: ", .maCasewiseDiagnosticsExportColumnsNames(diagnosticName))
-      .maExportScaleColumn(jaspResults, columnName, diagnosticsTable[[diagnosticName]], c(.maExportDependencies(), "exportDiagnosticsCaseDiagnostics"))
+      .maExportScaleColumn(jaspResults, columnName, diagnosticsTable[[diagnosticName]], c(.maExportDependencies(), "exportDiagnosticsCaseDiagnostics"), options)
     }
   }
 
   if (.maExportDiagnosticsModelImpact(options)) {
     for (diagnosticName in intersect(c("dffits", "cov.r", "tau.del", "tau2.del", "QE.del"), colnames(diagnosticsTable))) {
       columnName <- paste0("Diagnostics: ", .maCasewiseDiagnosticsExportColumnsNames(diagnosticName))
-      .maExportScaleColumn(jaspResults, columnName, diagnosticsTable[[diagnosticName]], c(.maExportDependencies(), "exportDiagnosticsModelImpact"))
+      .maExportScaleColumn(jaspResults, columnName, diagnosticsTable[[diagnosticName]], c(.maExportDependencies(), "exportDiagnosticsModelImpact"), options)
     }
   }
 
@@ -89,7 +175,7 @@
 
     for (diagnosticName in coefficientNames) {
       columnName <- decodeColNames(paste0("Difference in coefficients: ", .maVariableNames(diagnosticName, variables)))
-      .maExportScaleColumn(jaspResults, columnName, diagnosticsTable[[diagnosticName]], c(.maExportDependencies(), "exportDiagnosticsCoefficientInfluence"))
+      .maExportScaleColumn(jaspResults, columnName, diagnosticsTable[[diagnosticName]], c(.maExportDependencies(), "exportDiagnosticsCoefficientInfluence"), options)
     }
   }
 
@@ -132,15 +218,15 @@
   nRows <- .maExportDatasetRows(dataset)
 
   if (.maExportDiagnosticsInfluentialCases(options))
-    .maExportNominalColumn(jaspResults, "Diagnostics: Influential", rep(NA_character_, nRows), c(.maExportDependencies(), "exportDiagnosticsInfluentialCases"))
+    .maExportNominalColumn(jaspResults, "Diagnostics: Influential", rep(NA_character_, nRows), c(.maExportDependencies(), "exportDiagnosticsInfluentialCases"), options)
 
   if (.maExportDiagnosticsCaseDiagnostics(options))
-    .maExportScaleColumn(jaspResults, "Diagnostics: Cook's Distance", rep(NA_real_, nRows), c(.maExportDependencies(), "exportDiagnosticsCaseDiagnostics"))
+    .maExportScaleColumn(jaspResults, "Diagnostics: Cook's Distance", rep(NA_real_, nRows), c(.maExportDependencies(), "exportDiagnosticsCaseDiagnostics"), options)
 
   if (.maExportDiagnosticsModelImpact(options)) {
     for (diagnosticName in c("dffits", "cov.r", "tau.del", "tau2.del", "QE.del")) {
       columnName <- paste0("Diagnostics: ", .maCasewiseDiagnosticsExportColumnsNames(diagnosticName))
-      .maExportScaleColumn(jaspResults, columnName, rep(NA_real_, nRows), c(.maExportDependencies(), "exportDiagnosticsModelImpact"))
+      .maExportScaleColumn(jaspResults, columnName, rep(NA_real_, nRows), c(.maExportDependencies(), "exportDiagnosticsModelImpact"), options)
     }
   }
 
@@ -150,7 +236,7 @@
 
     for (diagnosticName in coefficientNames) {
       columnName <- decodeColNames(paste0("Difference in coefficients: ", .maVariableNames(diagnosticName, variables)))
-      .maExportScaleColumn(jaspResults, columnName, rep(NA_real_, nRows), c(.maExportDependencies(), "exportDiagnosticsCoefficientInfluence"))
+      .maExportScaleColumn(jaspResults, columnName, rep(NA_real_, nRows), c(.maExportDependencies(), "exportDiagnosticsCoefficientInfluence"), options)
     }
   }
 
@@ -191,7 +277,7 @@
       exportFunction = function(fit) stats::residuals(fit, type = "response"),
       isAvailable    = function(fit) .maExportFitSupportsResidual(fit, "response")
     )
-    .maExportScaleColumn(jaspResults, "Residuals: Raw", values, c(.maExportDependencies(), "exportResidualsRaw"))
+    .maExportScaleColumn(jaspResults, "Residuals: Raw", values, c(.maExportDependencies(), "exportResidualsRaw"), options)
   }
 
   if (isTRUE(options[["exportResidualsPearson"]])) {
@@ -201,7 +287,7 @@
       exportFunction = function(fit) stats::residuals(fit, type = "pearson"),
       isAvailable    = function(fit) .maExportFitSupportsResidual(fit, "pearson")
     )
-    .maExportScaleColumn(jaspResults, "Residuals: Pearson", values, c(.maExportDependencies(), "exportResidualsPearson"))
+    .maExportScaleColumn(jaspResults, "Residuals: Pearson", values, c(.maExportDependencies(), "exportResidualsPearson"), options)
   }
 
   if (isTRUE(options[["exportResidualsStandardized"]])) {
@@ -211,7 +297,7 @@
       exportFunction = function(fit) stats::residuals(fit, type = "rstandard"),
       isAvailable    = function(fit) .maExportFitSupportsResidual(fit, "rstandard")
     )
-    .maExportScaleColumn(jaspResults, "Residuals: Standardized", values, c(.maExportDependencies(), "exportResidualsStandardized"))
+    .maExportScaleColumn(jaspResults, "Residuals: Standardized", values, c(.maExportDependencies(), "exportResidualsStandardized"), options)
   }
 
   if (isTRUE(options[["exportResidualsStudentized"]])) {
@@ -221,7 +307,7 @@
       exportFunction = function(fit) stats::residuals(fit, type = "rstudent"),
       isAvailable    = function(fit) .maExportFitSupportsResidual(fit, "rstudent")
     )
-    .maExportScaleColumn(jaspResults, "Residuals: Studentized", values, c(.maExportDependencies(), "exportResidualsStudentized"))
+    .maExportScaleColumn(jaspResults, "Residuals: Studentized", values, c(.maExportDependencies(), "exportResidualsStudentized"), options)
   }
 
   if (isTRUE(options[["exportResidualsConditional"]]) && !.maIsMultilevelMultivariate(options)) {
@@ -231,7 +317,7 @@
       exportFunction = function(fit) stats::rstandard(fit, type = "conditional")[["z"]],
       isAvailable    = function(fit) .maExportFitSupportsResidual(fit, "conditional")
     )
-    .maExportScaleColumn(jaspResults, "Residuals: Conditional Standardized", values, c(.maExportDependencies(), "exportResidualsConditional"))
+    .maExportScaleColumn(jaspResults, "Residuals: Conditional Standardized", values, c(.maExportDependencies(), "exportResidualsConditional"), options)
   }
 
   return()
@@ -245,7 +331,7 @@
   fit     <- .maExportFitList(jaspResults, options)
   columns <- .maExportDataFrameFromFitList(dataset, fit, .maExportPredictedDataFrame, .maExportFitSupportsPredicted)
 
-  .maExportScaleColumns(jaspResults, columns, "Predicted Values", c(.maExportDependencies(), "exportPredictedValues"))
+  .maExportScaleColumns(jaspResults, columns, "Predicted Values", c(.maExportDependencies(), "exportPredictedValues"), options)
 
   return()
 }
@@ -258,7 +344,7 @@
   fit     <- .maExportFitList(jaspResults, options)
   columns <- .maExportDataFrameFromFitList(dataset, fit, .maExportTrueEffectDataFrame, .maExportFitSupportsTrueEffect)
 
-  .maExportScaleColumns(jaspResults, columns, "True Effect Estimates (BLUPs)", c(.maExportDependencies(), "exportTrueEffectEstimates"))
+  .maExportScaleColumns(jaspResults, columns, "True Effect Estimates (BLUPs)", c(.maExportDependencies(), "exportTrueEffectEstimates"), options)
 
   return()
 }
@@ -276,7 +362,7 @@
     columns <- .maExportDataFrameFromFitList(dataset, fit, .maExportRandomEffectsDataFrame, .maExportFitSupportsRandomEffects)
   }
 
-  .maExportScaleColumns(jaspResults, columns, "Random Effects", c(.maExportDependencies(), "exportRandomEffects"))
+  .maExportScaleColumns(jaspResults, columns, "Random Effects", c(.maExportDependencies(), "exportRandomEffects"), options)
 
   return()
 }
@@ -301,7 +387,7 @@
       },
       isAvailable    = .maExportFitSupportsWeights
     )
-    .maExportScaleColumn(jaspResults, "Weights: Row Sum", rowSumValues, c(.maExportDependencies(), "exportWeights"))
+    .maExportScaleColumn(jaspResults, "Weights: Row Sum", rowSumValues, c(.maExportDependencies(), "exportWeights"), options)
 
     diagonalValues <- .maExportVectorFromFitList(
       dataset        = dataset,
@@ -315,7 +401,7 @@
       },
       isAvailable    = .maExportFitSupportsWeights
     )
-    .maExportScaleColumn(jaspResults, "Weights: Diagonal", diagonalValues, c(.maExportDependencies(), "exportWeights"))
+    .maExportScaleColumn(jaspResults, "Weights: Diagonal", diagonalValues, c(.maExportDependencies(), "exportWeights"), options)
 
     return()
   }
@@ -332,7 +418,7 @@
     },
     isAvailable    = .maExportFitSupportsWeights
   )
-  .maExportScaleColumn(jaspResults, "Weights", values, c(.maExportDependencies(), "exportWeights"))
+  .maExportScaleColumn(jaspResults, "Weights", values, c(.maExportDependencies(), "exportWeights"), options)
 
   return()
 }
@@ -792,32 +878,34 @@
 # JASP column helpers ----
 
 .maExportDependencies                     <- function() {
-  return(c(.maDependencies, "includeFullDatasetInSubgroupAnalysis"))
+  return(c(.maDependencies, .maExportNameOptions, "includeFullDatasetInSubgroupAnalysis"))
 }
 
-.maExportScaleColumns                     <- function(jaspResults, columns, prefix, dependencies) {
+.maExportScaleColumns                     <- function(jaspResults, columns, prefix, dependencies, options) {
 
   for (columnName in names(columns))
-    .maExportScaleColumn(jaspResults, paste0(prefix, ": ", columnName), columns[[columnName]], dependencies)
+    .maExportScaleColumn(jaspResults, paste0(prefix, ": ", columnName), columns[[columnName]], dependencies, options)
 
   return()
 }
 
-.maExportScaleColumn                      <- function(jaspResults, columnName, values, dependencies) {
+.maExportScaleColumn                      <- function(jaspResults, columnName, values, dependencies, options) {
 
   if (is.null(values))
     return()
 
-  .metaValidateColumnName(columnName)
+  columnName <- .maExportColumnName(columnName, options)
+  .maValidateExportColumnName(columnName)
   jaspResults[[columnName]] <- createJaspColumn(columnName = columnName, dependencies = dependencies)
   jaspResults[[columnName]]$setScale(values)
 
   return()
 }
 
-.maExportNominalColumn                    <- function(jaspResults, columnName, values, dependencies) {
+.maExportNominalColumn                    <- function(jaspResults, columnName, values, dependencies, options) {
 
-  .metaValidateColumnName(columnName)
+  columnName <- .maExportColumnName(columnName, options)
+  .maValidateExportColumnName(columnName)
   jaspResults[[columnName]] <- createJaspColumn(columnName = columnName, dependencies = dependencies)
   jaspResults[[columnName]]$setNominal(values)
 

--- a/R/classicalmetaanalysis-exports.R
+++ b/R/classicalmetaanalysis-exports.R
@@ -516,7 +516,7 @@
 
 .maExportFitSupportsWeights               <- function(fit) {
   return(
-    inherits(fit, c("rma.uni", "rma.mv", "rma.glmm", "rma.mh", "rma.peto")) &&
+    inherits(fit, c("rma.uni", "rma.mv", "rma.mh", "rma.peto")) &&
       !inherits(fit, c("rma.gen", "rma.uni.selmodel"))
   )
 }

--- a/R/classicalmetaanalysis-model-summary-tables.R
+++ b/R/classicalmetaanalysis-model-summary-tables.R
@@ -212,6 +212,21 @@
   .maAddSeColumn(pooledEstimatesTable, options)
   .maAddCiColumn(pooledEstimatesTable, options)
   .maAddPiColumn(pooledEstimatesTable, options)
+
+  if (.maIsGLMM(options) && options[["glmmModel"]] == "UM.RS") {
+    showSigma <- options[["heterogeneityTau"]] || options[["heterogeneityTau2"]]
+    showRho   <- options[["glmmCorrelatedEffects"]] &&
+      (showSigma || options[["heterogeneityI2"]] || options[["heterogeneityH2"]])
+
+    if (showSigma && showRho) {
+      pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C3\u00B2 denotes study-level variability and \u03C1 denotes the correlation between study and group random effects."))
+    } else if (showSigma) {
+      pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C3\u00B2 denotes study-level variability."))
+    } else if (showRho) {
+      pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C1 denotes the correlation between study and group random effects."))
+    }
+  }
+
   if (options[["predictionIntervals"]] && .mammHasMultipleHeterogeneities(options, canAddOutput = TRUE)) {
     for (colName in .mammExtractTauLevelNamesList(fit)) {
       pooledEstimatesTable$addColumnInfo(name = colName, title = colName, type = .maGetVariableColumnType(colName, options), overtitle = gettext("Heterogeneity Level"))

--- a/R/classicalmetaanalysis-model-summary-tables.R
+++ b/R/classicalmetaanalysis-model-summary-tables.R
@@ -219,9 +219,9 @@
       (showSigma || options[["heterogeneityI2"]] || options[["heterogeneityH2"]])
 
     if (showSigma && showRho) {
-      pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C3\u00B2 denotes study-level variability and \u03C1 denotes the correlation between study and group random effects."))
+      pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C3 and \u03C3\u00B2 denote the study-level standard deviation and variance, respectively, and \u03C1 denotes the correlation between study and group random effects."))
     } else if (showSigma) {
-      pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C3\u00B2 denotes study-level variability."))
+      pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C3 and \u03C3\u00B2 denote the study-level standard deviation and variance, respectively."))
     } else if (showRho) {
       pooledEstimatesTable$addFootnote(gettext("For unconditional models with random study effects, \u03C1 denotes the correlation between study and group random effects."))
     }

--- a/R/classicalmetaanalysis.R
+++ b/R/classicalmetaanalysis.R
@@ -115,6 +115,11 @@ ClassicalMetaAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   "exportWeights"
 )
 
+.maExportNameOptions <- c(
+  "exportColumnPrefix",
+  "exportColumnPrefixValue"
+)
+
 .maForestPlotDependencies <- c(
   # do not forget to add variable carrying options to the .maDataPlottingDependencies
   "transformEffectSize", "confidenceIntervalsLevel", "bayesFactorType",

--- a/R/classicalmetaanalysiscommon.R
+++ b/R/classicalmetaanalysiscommon.R
@@ -86,14 +86,14 @@ ClassicalMetaAnalysisCommon <- function(jaspResults, dataset, options, ...) {
     .maVarianceInflationTable(jaspResults, options, "effectSize")
     .maVarianceInflationTable(jaspResults, options, "heterogeneity")
   }
-  if (options[["diagnosticsCasewiseDiagnostics"]]) {
+  if (!.maIsGLMM(options) && options[["diagnosticsCasewiseDiagnostics"]]) {
     .maCasewiseDiagnosticsTable(jaspResults, options)
   }
-  if (options[["diagnosticsPlotsProfileLikelihood"]])
+  if (!.maIsGLMM(options) && options[["diagnosticsPlotsProfileLikelihood"]])
     .maProfileLikelihoodPlot(jaspResults, options)
-  if (options[["diagnosticsPlotsBaujat"]])
+  if (!.maIsGLMM(options) && options[["diagnosticsPlotsBaujat"]])
     .maBaujatPlot(jaspResults, options)
-  if (options[["diagnosticsResidualFunnel"]])
+  if (!.maIsGLMM(options) && options[["diagnosticsResidualFunnel"]])
     .maResidualFunnelPlot(jaspResults, options)
 
   # export

--- a/inst/qml/ClassicalGeneralizedMetaAnalysis.qml
+++ b/inst/qml/ClassicalGeneralizedMetaAnalysis.qml
@@ -252,5 +252,10 @@ Form
 		analysisType:	"generalizedMetaAnalysis"
 	}
 
+	MA.ClassicalMetaAnalysisExport
+	{
+		analysisType:	"generalizedMetaAnalysis"
+	}
+
 	MA.ClassicalGeneralizedMetaAnalysisAdvanced {}
 }

--- a/inst/qml/ClassicalGeneralizedMetaAnalysis.qml
+++ b/inst/qml/ClassicalGeneralizedMetaAnalysis.qml
@@ -126,7 +126,7 @@ Form
 			id:				glmmModel
 			label:			qsTr("Model type")
 			startValue:		"UM.FS"
-			info: qsTr("Select the generalized linear model type. UM.FS = unconditional with fixed study effects (default); UM.RS = unconditional with random study effects; CM.AL = conditional with approximate likelihood (odds ratios only); CM.EL = conditional with exact likelihood (odds ratios and incidence rate ratios).")
+			info: qsTr("Select the generalized linear model type. Unconditional with fixed study effects (UM.FS; default); unconditional with random study effects (UM.RS); conditional with approximate likelihood (CM.AL; odds ratios only); conditional with exact likelihood (CM.EL; odds ratios and incidence rate ratios).")
 			values: (function() {
 				if (effectSizeMeasure.value === "OR") {
 					return [

--- a/inst/qml/qml_components/ClassicalGeneralizedMetaAnalysisAdvanced.qml
+++ b/inst/qml/qml_components/ClassicalGeneralizedMetaAnalysisAdvanced.qml
@@ -75,7 +75,7 @@ Section
 			label:		qsTr("Correlated random effects")
 			checked:	false
 			visible:	glmmModel.value === "UM.RS"
-			info: qsTr("Allow correlated random effects in the UM.RS model (random study effects and random treatment effects can be correlated).")
+			info: qsTr("Allow the random study effects and random treatment effects to be correlated in the unconditional model with random study effects.")
 		}
 
 		IntegerField

--- a/inst/qml/qml_components/ClassicalMetaAnalysisDiagnostics.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisDiagnostics.qml
@@ -26,8 +26,9 @@ Section
 	property string analysisType:	"metaAnalysis"
 	property int heterogeneityModelTermsCount: 0
 	readonly property bool locationScaleModel: analysisType === "metaAnalysis" && heterogeneityModelTermsCount > 0
+	readonly property bool generalizedMetaAnalysis: analysisType === "generalizedMetaAnalysis"
 	columns:						1
-	info: qsTr("Options for evaluating the influence of individual studies and assessing model diagnostics, including variance inflation factors, casewise diagnostics, and diagnostic plots.")
+	info: generalizedMetaAnalysis ? qsTr("Options for assessing multicollinearity among predictors.") : qsTr("Options for evaluating the influence of individual studies and assessing model diagnostics, including variance inflation factors, casewise diagnostics, and diagnostic plots.")
 
 	Group
 	{
@@ -40,8 +41,8 @@ Section
 				name:		"diagnosticsVarianceInflationFactor"
 				text:		qsTr("Variance inflation factor")
 				Layout.preferredWidth: 300 * jaspTheme.uiScale
-				visible:	analysisType === "metaAnalysis" || analysisType === "multilevelMultivariateMetaAnalysis"
-				enabled:	(analysisType === "metaAnalysis" || analysisType === "multilevelMultivariateMetaAnalysis") && predictors.count > 0
+				visible:	analysisType === "metaAnalysis" || analysisType === "multilevelMultivariateMetaAnalysis" || generalizedMetaAnalysis
+				enabled:	(analysisType === "metaAnalysis" || analysisType === "multilevelMultivariateMetaAnalysis" || generalizedMetaAnalysis) && predictors.count > 0
 				info: qsTr("Include variance inflation factors to assess multicollinearity among predictors. Available when predictors are included in the model.")
 
 				CheckBox
@@ -101,6 +102,7 @@ Section
 		Group
 		{
 			title:		qsTr("Plots")
+			visible:	!generalizedMetaAnalysis
 
 			CheckBox
 			{

--- a/inst/qml/qml_components/ClassicalMetaAnalysisExport.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisExport.qml
@@ -26,6 +26,7 @@ Section
 	property string analysisType:				"metaAnalysis"
 	property int heterogeneityModelTermsCount:	0
 	readonly property bool locationScaleModel: analysisType === "metaAnalysis" && heterogeneityModelTermsCount > 0
+	readonly property bool generalizedMetaAnalysis: analysisType === "generalizedMetaAnalysis"
 	columns:									2
 	info: qsTr("Options for exporting model-derived quantities to the dataset.")
 
@@ -76,13 +77,14 @@ Section
 		{
 			name:	"exportResidualsRaw"
 			text:	qsTr("Raw")
-			info: qsTr("Export raw residuals.")
+			info: generalizedMetaAnalysis ? qsTr("Export observed-minus-fitted residuals on the effect-size scale.") : qsTr("Export raw residuals.")
 		}
 
 		CheckBox
 		{
 			name:	"exportResidualsPearson"
 			text:	qsTr("Pearson")
+			visible:	!generalizedMetaAnalysis
 			info: qsTr("Export Pearson residuals.")
 		}
 
@@ -90,6 +92,7 @@ Section
 		{
 			name:	"exportResidualsStandardized"
 			text:	qsTr("Standardized")
+			visible:	!generalizedMetaAnalysis
 			info: qsTr("Export standardized residuals.")
 		}
 
@@ -97,6 +100,7 @@ Section
 		{
 			name:		"exportResidualsStudentized"
 			text:		qsTr("Studentized")
+			visible:	!generalizedMetaAnalysis
 			enabled:	!locationScaleModel
 			info: qsTr("Export studentized residuals.")
 		}
@@ -133,6 +137,7 @@ Section
 		{
 			name:	"exportRandomEffects"
 			text:	qsTr("Random effects")
+			visible:	!generalizedMetaAnalysis
 			info: qsTr("Export predicted random effects.")
 		}
 
@@ -140,6 +145,7 @@ Section
 		{
 			name:	"exportWeights"
 			text:	qsTr("Weights")
+			visible:	!generalizedMetaAnalysis
 			info: qsTr("Export model fitting weights. These are not coefficient-specific contribution weights in meta-regression. For multilevel/multivariate models, diagonal weights match the default forest plot weights and row-sum weights are exported for intercept-only models.")
 		}
 	}

--- a/inst/qml/qml_components/ClassicalMetaAnalysisExport.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisExport.qml
@@ -30,6 +30,24 @@ Section
 	columns:									2
 	info: qsTr("Options for exporting model-derived quantities to the dataset.")
 
+	CheckBox
+	{
+		Layout.columnSpan:	2
+		id:					exportColumnPrefix
+		name:				"exportColumnPrefix"
+		text:				qsTr("Prefix exported column names")
+		childrenOnSameRow:	true
+		info: qsTr("Add a prefix to every column exported by this analysis.")
+
+		TextField
+		{
+			name:			"exportColumnPrefixValue"
+			placeholderText:	qsTr("Prefix")
+			fieldWidth:		120
+			info: qsTr("Prefix added to every exported column name.")
+		}
+	}
+
 	Group
 	{
 		title:		qsTr("Diagnostics")


### PR DESCRIPTION
## Fixed
* Restored GLMM diagnostics and exports, exposing variance inflation factors, raw residuals, and predicted values.
* Added study-level variability and random-effects correlation estimates for unconditional models with random study effects.