### PR TITLE
Fix ordinal moderator casting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspMetaAnalysis
 Type: Package
 Title: Meta-Analysis Module for JASP
-Version: 0.97.2
+Version: 0.97.3
 Date: 2022-10-05
 Author: JASP Team
 Website: jasp-stats.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 >   * **Deprecated / Removed:** Outdated analyses, options, or legacy code.
 
 ---
+# jaspMetaAnalysis 0.97.3
+## Fixed
+* Predictor type casts not being preserved in estimated marginal means and prediction plots.
+
 # jaspMetaAnalysis 0.97.2
 ## Fixed
 * Meta-analytic SEM failing to load because JASP wipes OpenMx `mxOptions` before `metaSEM` `.onLoad`.

--- a/inst/qml/qml_components/BubblePlot.qml
+++ b/inst/qml/qml_components/BubblePlot.qml
@@ -43,6 +43,7 @@ Section
 			id:				bubblePlotSelectedVariable
 			title:			qsTr("Selected Variable")
 			singleVariable:	true
+			allowedColumns:	["scale", "nominal"]
 			allowTypeChange:false
 			info: qsTr("Variable to be visualized on the x-axis.")
 		}
@@ -52,6 +53,7 @@ Section
 			name:			"bubblePlotSeparateLines"
 			id:				bubblePlotSeparateLines
 			title:			qsTr("Separate Lines")
+			allowedColumns:	["scale", "nominal"]
 			allowTypeChange:false
 			info: qsTr("Variable(s) according to which predictions are split across different lines.")
 		}
@@ -61,6 +63,7 @@ Section
 			name:			"bubblePlotSeparatePlots"
 			id:				bubblePlotSeparatePlots
 			title:			qsTr("Separate Plots")
+			allowedColumns:	["scale", "nominal"]
 			allowTypeChange:false
 			info: qsTr("Variable(s) according to which predictions are split across different plots.")
 		}

--- a/inst/qml/qml_components/ClassicalMetaAnalysisEstimatedMarginalMeans.qml
+++ b/inst/qml/qml_components/ClassicalMetaAnalysisEstimatedMarginalMeans.qml
@@ -48,6 +48,7 @@ Section
 				id:				estimatedMarginalMeansEffectSizeSelectedVariables
 				name:			"estimatedMarginalMeansEffectSizeSelectedVariables"
 				title:			qsTr("Selected Variables")
+				allowedColumns:	["scale", "nominal"]
 				allowTypeChange:false
 				info: qsTr("Variables selected for computing estimated marginal means in the effect size model.")
 			}
@@ -142,6 +143,7 @@ Section
 				id:				estimatedMarginalMeansHeterogeneitySelectedVariables
 				name:			"estimatedMarginalMeansHeterogeneitySelectedVariables"
 				title:			qsTr("Selected Variables")
+				allowedColumns:	["scale", "nominal"]
 				allowTypeChange:false
 				info: qsTr("Variables selected for computing estimated marginal means in the heterogeneity model. Unavailable when performing multilevel/multivariate meta-analysis.")
 			}

--- a/inst/qml/qml_components/ForestPlotSection.qml
+++ b/inst/qml/qml_components/ForestPlotSection.qml
@@ -98,6 +98,7 @@ Section
 				id:				forestPlotEstimatedMarginalMeansSelectedVariables
 				name:			"forestPlotEstimatedMarginalMeansSelectedVariables"
 				title:			qsTr("Selected Variables")
+				allowedColumns:	["scale", "nominal"]
 				allowTypeChange:false
 				info: qsTr("Select variables for which the estimated marginal means are visualized.")
 			}

--- a/inst/qml/qml_components/RobustBayesianMetaAnalysisEstimatedMarginalMeans.qml
+++ b/inst/qml/qml_components/RobustBayesianMetaAnalysisEstimatedMarginalMeans.qml
@@ -52,6 +52,7 @@ Section
 				id:				estimatedMarginalMeansEffectSizeSelectedVariables
 				name:			"estimatedMarginalMeansEffectSizeSelectedVariables"
 				title:			qsTr("Selected Variables")
+				allowedColumns:	["scale", "nominal"]
 				allowTypeChange:false
 				info: qsTr("Variables selected for computing estimated marginal means in the effect size model.")
 			}


### PR DESCRIPTION
Add allowedColumns: ["scale","nominal"] to variable selector controls to restrict selectable variable types to scale or nominal. Prevents invalid type selection in BubblePlot, ForestPlot and Estimated Marginal Means UI components.

fixes: https://github.com/jasp-stats/jasp-issues/issues/4481